### PR TITLE
Implement fast streaming for intra-node migration

### DIFF
--- a/alternator/ttl.cc
+++ b/alternator/ttl.cc
@@ -383,6 +383,9 @@ static std::vector<std::pair<dht::token_range, gms::inet_address>> get_secondary
 // the chances of covering all ranges during a scan when restarts occur.
 // A more deterministic way would be to regularly persist the scanning state,
 // but that incurs overhead that we want to avoid if not needed.
+//
+// FIXME: Check if this algorithm is safe with tablet migration.
+// https://github.com/scylladb/scylladb/issues/16567
 enum primary_or_secondary_t {primary, secondary};
 template<primary_or_secondary_t primary_or_secondary>
 class token_ranges_owned_by_this_shard {

--- a/api/api-doc/storage_service.json
+++ b/api/api-doc/storage_service.json
@@ -2727,6 +2727,22 @@
          ]
       },
       {
+         "path":"/storage_service/quiesce_topology",
+         "operations":[
+            {
+               "nickname":"quiesce_topology",
+               "method":"POST",
+               "summary":"Waits until there are no ongoing topology operations",
+               "type":"void",
+               "produces":[
+                  "application/json"
+               ],
+               "parameters":[
+               ]
+            }
+         ]
+      },
+      {
          "path":"/storage_service/metrics/total_hints",
          "operations":[
             {

--- a/api/storage_service.cc
+++ b/api/storage_service.cc
@@ -1626,6 +1626,11 @@ void set_storage_service(http_context& ctx, routes& r, sharded<service::storage_
         co_return json_void();
     });
 
+    ss::quiesce_topology.set(r, [&ss] (std::unique_ptr<http::request> req) -> future<json_return_type> {
+        co_await ss.local().await_topology_quiesced();
+        co_return json_void();
+    });
+
     sp::get_schema_versions.set(r, [&ss](std::unique_ptr<http::request> req)  {
         return ss.local().describe_schema_versions().then([] (auto result) {
             std::vector<sp::mapper_list> res;
@@ -1729,6 +1734,7 @@ void unset_storage_service(http_context& ctx, routes& r) {
     ss::add_tablet_replica.unset(r);
     ss::del_tablet_replica.unset(r);
     ss::tablet_balancing_enable.unset(r);
+    ss::quiesce_topology.unset(r);
     sp::get_schema_versions.unset(r);
 }
 

--- a/cdc/generation.cc
+++ b/cdc/generation.cc
@@ -184,7 +184,7 @@ static std::vector<stream_id> create_stream_ids(
         size_t index, dht::token start, dht::token end, size_t shard_count, uint8_t ignore_msb) {
     std::vector<stream_id> result;
     result.reserve(shard_count);
-    dht::sharder sharder(shard_count, ignore_msb);
+    dht::static_sharder sharder(shard_count, ignore_msb);
     for (size_t shard_idx = 0; shard_idx < shard_count; ++shard_idx) {
         auto t = dht::find_first_token_for_shard(sharder, start, end, shard_idx);
         // compose the id from token and the "index" of the range end owning vnode

--- a/compaction/compaction.cc
+++ b/compaction/compaction.cc
@@ -1701,7 +1701,12 @@ public:
     }
 
     compaction_writer create_compaction_writer(const dht::decorated_key& dk) override {
-        auto shard = _sharder->shard_of(dk.token());
+        auto shards = _sharder->shard_for_writes(dk.token());
+        if (shards.size() != 1) {
+            // Resharding is not supposed to run on tablets, so this case does not have to be supported.
+            on_internal_error(clogger, fmt::format("Got {} shards for token {} in table {}.{}", shards.size(), dk.token(), _schema->ks_name(), _schema->cf_name()));
+        }
+        auto shard = shards[0];
         auto sst = _sstable_creator(shard);
         setup_new_sstable(sst);
 

--- a/cql3/statements/create_keyspace_statement.cc
+++ b/cql3/statements/create_keyspace_statement.cc
@@ -117,9 +117,10 @@ future<std::tuple<::shared_ptr<cql_transport::event::schema_change>, std::vector
         if (rs->uses_tablets()) {
             warnings.push_back(
                 "Tables in this keyspace will be replicated using tablets, "
-                "and will not support the CDC feature (issue #16317) and LWT "
-                "may suffer from issue #5251 more often. If you want to use "
-                "CDC or LWT, please drop this keyspace and re-create it "
+                "and will not support the CDC feature (issue #16317), "
+                "counters (issue #18180) "
+                "and LWT may suffer from issue #5251 more often. If you want to use "
+                "CDC, counters or LWT, please drop this keyspace and re-create it "
                 "without tablets, by adding AND TABLETS = {'enabled': false} "
                 "to the CREATE KEYSPACE statement.");
         }

--- a/cql3/statements/select_statement.cc
+++ b/cql3/statements/select_statement.cc
@@ -423,7 +423,7 @@ select_statement::do_execute(query_processor& qp,
              throw exceptions::invalid_request_exception(
                      "SERIAL/LOCAL_SERIAL consistency may only be requested for one partition at a time");
         }
-        unsigned shard = table.shard_of(key_ranges[0].start()->value().as_decorated_key().token());
+        unsigned shard = table.shard_for_reads(key_ranges[0].start()->value().as_decorated_key().token());
         if (this_shard_id() != shard) {
             return make_ready_future<shared_ptr<cql_transport::messages::result_message>>(
                     qp.bounce_to_shard(shard, std::move(const_cast<cql3::query_options&>(options).take_cached_pk_function_calls()))

--- a/dht/auto_refreshing_sharder.hh
+++ b/dht/auto_refreshing_sharder.hh
@@ -46,6 +46,10 @@ public:
         return _sharder->shard_of(token);
     }
 
+    virtual dht::shard_replica_set shard_for_writes(const token& t) const override {
+        return _sharder->shard_for_writes(t);
+    }
+
     virtual std::optional<dht::shard_and_token> next_shard(const dht::token& t) const override {
         return _sharder->next_shard(t);
     }

--- a/dht/auto_refreshing_sharder.hh
+++ b/dht/auto_refreshing_sharder.hh
@@ -44,8 +44,8 @@ public:
 
     virtual ~auto_refreshing_sharder() = default;
 
-    virtual unsigned shard_of(const dht::token& token) const override {
-        return _sharder->shard_of(token);
+    virtual unsigned shard_for_reads(const token& t) const override {
+        return _sharder->shard_for_reads(t);
     }
 
     virtual dht::shard_replica_set shard_for_writes(const token& t, std::optional<write_replica_set_selector> sel) const override {
@@ -55,12 +55,12 @@ public:
         return _sharder->shard_for_writes(t, sel);
     }
 
-    virtual std::optional<dht::shard_and_token> next_shard(const dht::token& t) const override {
-        return _sharder->next_shard(t);
+    virtual std::optional<dht::shard_and_token> next_shard_for_reads(const dht::token& t) const override {
+        return _sharder->next_shard_for_reads(t);
     }
 
-    virtual dht::token token_for_next_shard(const dht::token& t, shard_id shard, unsigned spans = 1) const override {
-        return _sharder->token_for_next_shard(t, shard, spans);
+    virtual dht::token token_for_next_shard_for_reads(const dht::token& t, shard_id shard, unsigned spans = 1) const override {
+        return _sharder->token_for_next_shard_for_reads(t, shard, spans);
     }
 };
 

--- a/dht/i_partitioner.cc
+++ b/dht/i_partitioner.cc
@@ -38,6 +38,11 @@ sharder::shard_of(const token& t) const {
     return dht::shard_of(_shard_count, _sharding_ignore_msb_bits, t);
 }
 
+shard_replica_set
+sharder::shard_for_writes(const token& t) const {
+    return {shard_of(t)};
+}
+
 token
 sharder::token_for_next_shard(const token& t, shard_id shard, unsigned spans) const {
     return dht::token_for_next_shard(_shard_start, _shard_count, _sharding_ignore_msb_bits, t, shard, spans);

--- a/dht/i_partitioner.cc
+++ b/dht/i_partitioner.cc
@@ -232,7 +232,7 @@ ring_position_range_vector_sharder::next(const schema& s) {
 }
 
 future<utils::chunked_vector<partition_range>>
-split_range_to_single_shard(const schema& s, const sharder& sharder, const partition_range& pr, shard_id shard) {
+split_range_to_single_shard(const schema& s, const static_sharder& sharder, const partition_range& pr, shard_id shard) {
     auto start_token = pr.start() ? pr.start()->value().token() : minimum_token();
     auto start_shard = sharder.shard_of(start_token);
     auto start_boundary = start_shard == shard ? pr.start() : interval_bound<ring_position>(ring_position::starting_at(sharder.token_for_next_shard(start_token, shard)));

--- a/dht/i_partitioner.cc
+++ b/dht/i_partitioner.cc
@@ -39,7 +39,7 @@ sharder::shard_of(const token& t) const {
 }
 
 shard_replica_set
-sharder::shard_for_writes(const token& t) const {
+sharder::shard_for_writes(const token& t, std::optional<write_replica_set_selector> sel) const {
     return {shard_of(t)};
 }
 

--- a/dht/i_partitioner.cc
+++ b/dht/i_partitioner.cc
@@ -34,25 +34,25 @@ sharder::sharder(unsigned shard_count, unsigned sharding_ignore_msb_bits)
 {}
 
 unsigned
-sharder::shard_of(const token& t) const {
+sharder::shard_for_reads(const token& t) const {
     return dht::shard_of(_shard_count, _sharding_ignore_msb_bits, t);
 }
 
 shard_replica_set
 sharder::shard_for_writes(const token& t, std::optional<write_replica_set_selector> sel) const {
-    return {shard_of(t)};
+    return {shard_for_reads(t)};
 }
 
 token
-sharder::token_for_next_shard(const token& t, shard_id shard, unsigned spans) const {
+sharder::token_for_next_shard_for_reads(const token& t, shard_id shard, unsigned spans) const {
     return dht::token_for_next_shard(_shard_start, _shard_count, _sharding_ignore_msb_bits, t, shard, spans);
 }
 
 std::optional<shard_and_token>
-sharder::next_shard(const token& t) const {
-    auto shard = shard_of(t);
+sharder::next_shard_for_reads(const token& t) const {
+    auto shard = shard_for_reads(t);
     auto next_shard = shard + 1 == _shard_count ? 0 : shard + 1;
-    auto next_token = token_for_next_shard(t, next_shard);
+    auto next_token = token_for_next_shard_for_reads(t, next_shard);
     if (next_token == dht::maximum_token()) {
         return std::nullopt;
     }
@@ -136,7 +136,7 @@ decorated_key::less_comparator::operator()(const decorated_key& lhs, const ring_
 }
 
 unsigned static_shard_of(const schema& s, const token& t) {
-    return s.get_sharder().shard_of(t);
+    return s.get_sharder().shard_for_reads(t);
 }
 
 std::optional<dht::token_range>

--- a/dht/i_partitioner.cc
+++ b/dht/i_partitioner.cc
@@ -484,11 +484,11 @@ dht::token first_token(const dht::partition_range& pr) {
 
 std::optional<shard_id> is_single_shard(const dht::sharder& sharder, const schema& s, const dht::partition_range& pr) {
     auto token = first_token(pr);
-    auto shard = sharder.shard_of(token);
+    auto shard = sharder.shard_for_reads(token);
     if (pr.is_singular()) {
         return shard;
     }
-    if (auto s_a_t = sharder.next_shard(token)) {
+    if (auto s_a_t = sharder.next_shard_for_reads(token)) {
         dht::ring_position_comparator cmp(s);
         auto end = dht::ring_position_view::for_range_end(pr);
         if (cmp(end, dht::ring_position_view::starting_at(s_a_t->token)) > 0) {

--- a/dht/i_partitioner.cc
+++ b/dht/i_partitioner.cc
@@ -165,10 +165,10 @@ selective_token_range_sharder::next() {
     }
     while (_range.overlaps(dht::token_range(_start_boundary, {}), dht::token_comparator())
             && !(_start_boundary && _start_boundary->value() == maximum_token())) {
-        auto end_token = _sharder.token_for_next_shard(_start_token, _next_shard);
+        auto end_token = _sharder.token_for_next_shard_for_reads(_start_token, _next_shard);
         auto candidate = dht::token_range(std::move(_start_boundary), interval_bound<dht::token>(end_token, false));
         auto intersection = _range.intersection(std::move(candidate), dht::token_comparator());
-        _start_token = _sharder.token_for_next_shard(end_token, _shard);
+        _start_token = _sharder.token_for_next_shard_for_reads(end_token, _shard);
         _start_boundary = interval_bound<dht::token>(_start_token);
         if (intersection) {
             return *intersection;

--- a/dht/i_partitioner.cc
+++ b/dht/i_partitioner.cc
@@ -185,8 +185,8 @@ ring_position_range_sharder::next(const schema& s) {
         return {};
     }
     auto token = _range.start() ? _range.start()->value().token() : dht::minimum_token();
-    auto shard = _sharder.shard_of(token);
-    auto next_shard_and_token = _sharder.next_shard(token);
+    auto shard = _sharder.shard_for_reads(token);
+    auto next_shard_and_token = _sharder.next_shard_for_reads(token);
     if (!next_shard_and_token) {
         _done = true;
         return ring_position_range_and_shard{std::move(_range), shard};

--- a/dht/i_partitioner.hh
+++ b/dht/i_partitioner.hh
@@ -74,7 +74,12 @@ public:
 };
 
 // Returns the owning shard number for vnode-based replication strategies.
-// Use table::shard_of() for the general case.
+// For the general case, use the sharder obtained from table's effective replication map.
+//
+//   table& tbl;
+//   auto erm = tbl.get_effective_replication_map();
+//   auto& sharder = erm->get_sharder();
+//
 unsigned static_shard_of(const schema&, const token&);
 
 inline decorated_key decorate_key(const schema& s, const partition_key& key) {

--- a/dht/i_partitioner.hh
+++ b/dht/i_partitioner.hh
@@ -120,6 +120,7 @@ dht::token first_token(const dht::partition_range&);
 
 // Returns true iff a given partition range is wholly owned by a single shard.
 // If so, returns that shard. Otherwise, return std::nullopt.
+// During tablet migration, uses the view on shard ownership for reads.
 std::optional<shard_id> is_single_shard(const dht::sharder&, const schema&, const dht::partition_range&);
 
 } // dht

--- a/dht/i_partitioner.hh
+++ b/dht/i_partitioner.hh
@@ -100,9 +100,9 @@ dht::partition_range_vector to_partition_ranges(const dht::token_range_vector& r
 std::map<unsigned, dht::partition_range_vector>
 split_range_to_shards(dht::partition_range pr, const schema& s, const sharder& sharder);
 
-// Intersect a partition_range with a shard and return the the resulting sub-ranges, in sorted order
+// Intersect a partition_range with a shard and return the resulting sub-ranges, in sorted order
 future<utils::chunked_vector<partition_range>> split_range_to_single_shard(const schema& s,
-    const sharder& sharder, const dht::partition_range& pr, shard_id shard);
+    const static_sharder& sharder, const dht::partition_range& pr, shard_id shard);
 
 std::unique_ptr<dht::i_partitioner> make_partitioner(sstring name);
 

--- a/dht/sharder.hh
+++ b/dht/sharder.hh
@@ -117,6 +117,7 @@ public:
 
 // Incrementally divides a `partition_range` into sub-ranges wholly owned by a single shard.
 // Unlike ring_position_range_sharder, it only returns result for a shard number provided by the caller.
+// During topology changes, reflects shard assignment for reads.
 class selective_token_range_sharder {
     const sharder& _sharder;
     dht::token_range _range;
@@ -133,8 +134,8 @@ public:
             , _shard(shard)
             , _next_shard(_shard + 1 == _sharder.shard_count() ? 0 : _shard + 1)
             , _start_token(_range.start() ? _range.start()->value() : minimum_token())
-            , _start_boundary(_sharder.shard_of(_start_token) == shard ?
-                _range.start() : interval_bound<dht::token>(_sharder.token_for_next_shard(_start_token, shard))) {
+            , _start_boundary(_sharder.shard_for_reads(_start_token) == shard ?
+                _range.start() : interval_bound<dht::token>(_sharder.token_for_next_shard_for_reads(_start_token, shard))) {
     }
     // Returns the next token_range that is both wholly contained within the input range and also
     // wholly owned by the input shard_id. When the input range is exhausted, std::nullopt is returned.

--- a/dht/sharder.hh
+++ b/dht/sharder.hh
@@ -42,6 +42,7 @@ struct ring_position_range_and_shard {
 };
 
 // Incrementally divides a `partition_range` into sub-ranges wholly owned by a single shard.
+// During tablet migration uses a view on shard routing for reads.
 class ring_position_range_sharder {
     const sharder& _sharder;
     dht::partition_range _range;
@@ -74,7 +75,7 @@ struct ring_position_range_and_shard_and_element : ring_position_range_and_shard
 // Incrementally divides several non-overlapping `partition_range`:s into sub-ranges wholly owned by
 // a single shard.
 //
-// Similar to ring_position_range_sharder, but instead of stopping when the input range is exhauseted,
+// Similar to ring_position_range_sharder, but instead of stopping when the input range is exhausted,
 // moves on to the next input range (input ranges are supplied in a vector).
 //
 // This has two use cases:
@@ -85,7 +86,8 @@ struct ring_position_range_and_shard_and_element : ring_position_range_and_shard
 // 2. sstable shard mappings. An sstable has metadata describing which ranges it owns, and this is
 //    used to see what shards these ranges map to (and therefore to see if the sstable is shared or
 //    not, and which shards share it).
-
+//
+// During migration uses a view on shard routing for reads.
 class ring_position_range_vector_sharder {
     using vec_type = dht::partition_range_vector;
     vec_type _ranges;

--- a/dht/token-sharding.hh
+++ b/dht/token-sharding.hh
@@ -10,6 +10,7 @@
 
 #include "dht/token.hh"
 #include <seastar/core/smp.hh>
+#include <boost/container/static_vector.hpp>
 
 namespace dht {
 
@@ -28,6 +29,10 @@ struct shard_and_token {
     token token;
 };
 
+/// Represents a set of shards that own a given token on a single host.
+/// It can be either of: none, single shard (no tablet migration), or two shards (during intra-node tablet migration).
+using shard_replica_set = boost::container::static_vector<unsigned, 2>;
+
 /**
  * Describes mapping between token space of a given table and owning shards on the local node.
  * The mapping reflected by this instance is constant for the lifetime of this sharder object.
@@ -45,9 +50,18 @@ public:
     sharder(unsigned shard_count = smp::count, unsigned sharding_ignore_msb_bits = 0);
     virtual ~sharder() = default;
     /**
-     * Calculates the shard that handles a particular token.
+     * Calculates the shard that handles a particular token for reads.
+     * Use shard_for_writes() to determine the set of shards that should receive writes.
      */
     virtual unsigned shard_of(const token& t) const;
+
+    /**
+     * Returns the set of shards which should receive a write to token t.
+     * During intra-node tablet migration, local writes need to be replicated to both the old and new shard.
+     * You should keep the effective_replication_map_ptr used to obtain this sharder alive around performing
+     * the writes so that topology coordinator can wait for all writes using this particular topology version.
+     */
+    virtual shard_replica_set shard_for_writes(const token& t) const;
 
     /**
      * Gets the first token greater than `t` that is in shard `shard`, and is a shard boundary (its first token).
@@ -112,3 +126,21 @@ struct fmt::formatter<dht::sharder> {
                               sharder.shard_count(), sharder.sharding_ignore_msb());
     }
 };
+
+template<>
+struct fmt::formatter<dht::shard_replica_set> : fmt::formatter<std::string_view> {
+    template <typename FormatContext>
+    auto format(const dht::shard_replica_set& rs, FormatContext& ctx) const {
+        return fmt::format_to(ctx.out(), "{{{}}}", fmt::join(rs, ", "));
+    }
+};
+
+namespace std {
+
+inline
+std::ostream& operator<<(std::ostream& out, const dht::shard_replica_set& rs) {
+    fmt::print(out, "{}", rs);
+    return out;
+}
+
+} // namespace std

--- a/dht/token-sharding.hh
+++ b/dht/token-sharding.hh
@@ -176,7 +176,7 @@ public:
  * when going from 100 to 10 on the ring.
  */
 dht::token find_first_token_for_shard(
-        const dht::sharder& sharder, dht::token start, dht::token end, size_t shard_idx);
+        const dht::static_sharder& sharder, dht::token start, dht::token end, size_t shard_idx);
 
 } //namespace dht
 

--- a/dht/token-sharding.hh
+++ b/dht/token-sharding.hh
@@ -33,6 +33,11 @@ struct shard_and_token {
 /// It can be either of: none, single shard (no tablet migration), or two shards (during intra-node tablet migration).
 using shard_replica_set = boost::container::static_vector<unsigned, 2>;
 
+/// Describes which replica set should be used during tablet migration.
+enum class write_replica_set_selector {
+    previous, both, next
+};
+
 /**
  * Describes mapping between token space of a given table and owning shards on the local node.
  * The mapping reflected by this instance is constant for the lifetime of this sharder object.
@@ -61,7 +66,7 @@ public:
      * You should keep the effective_replication_map_ptr used to obtain this sharder alive around performing
      * the writes so that topology coordinator can wait for all writes using this particular topology version.
      */
-    virtual shard_replica_set shard_for_writes(const token& t) const;
+    virtual shard_replica_set shard_for_writes(const token& t, std::optional<write_replica_set_selector> sel = std::nullopt) const;
 
     /**
      * Gets the first token greater than `t` that is in shard `shard`, and is a shard boundary (its first token).

--- a/dht/token-sharding.hh
+++ b/dht/token-sharding.hh
@@ -53,14 +53,6 @@ protected:
 public:
     sharder(unsigned shard_count = smp::count, unsigned sharding_ignore_msb_bits = 0);
     virtual ~sharder() = default;
-    /**
-     * Calculates the shard that handles a particular token for reads.
-     * Use shard_for_writes() to determine the set of shards that should receive writes.
-     */
-    [[deprecated("Use shard_for_reads()/shard_for_writes() instead")]]
-    virtual unsigned shard_of(const token& t) const {
-        return shard_for_reads(t);
-    }
 
     /**
      * Returns the shard that handles a particular token for reads.
@@ -104,11 +96,6 @@ public:
      */
     virtual token token_for_next_shard_for_reads(const token& t, shard_id shard, unsigned spans = 1) const = 0;
 
-    [[deprecated("Use token_for_next_shard_for_reads() instead")]]
-    virtual token token_for_next_shard(const token& t, shard_id shard, unsigned spans = 1) const {
-        return token_for_next_shard_for_reads(t, shard, spans);
-    }
-
     /**
      * Finds the next token greater than t which is owned by a different shard than the owner of t
      * and returns that token and its owning shard. If no such token exists, returns nullopt.
@@ -120,11 +107,6 @@ public:
      *     shard_for_reads(next_shard(t)->token) == next_shard(t)->shard
      */
     virtual std::optional<shard_and_token> next_shard_for_reads(const token& t) const = 0;
-
-    [[deprecated("Use next_shard_for_reads() instead")]]
-    virtual std::optional<shard_and_token> next_shard(const token& t) const {
-        return next_shard_for_reads(t);
-    }
 
     /**
      * @return number of shards configured for this partitioner

--- a/dht/token.cc
+++ b/dht/token.cc
@@ -238,7 +238,7 @@ dht::token token::from_int64(int64_t i) {
 }
 
 static
-dht::token find_first_token_for_shard_in_not_wrap_around_range(const dht::sharder& sharder, dht::token start, dht::token end, size_t shard_idx) {
+dht::token find_first_token_for_shard_in_not_wrap_around_range(const dht::static_sharder& sharder, dht::token start, dht::token end, size_t shard_idx) {
     // Invariant start < end
     // It is guaranteed that start is not MAX_INT64 because end is greater
     auto t = dht::token::from_int64(dht::token::to_int64(start) + 1);
@@ -249,7 +249,7 @@ dht::token find_first_token_for_shard_in_not_wrap_around_range(const dht::sharde
 }
 
 dht::token find_first_token_for_shard(
-        const dht::sharder& sharder, dht::token start, dht::token end, size_t shard_idx) {
+        const dht::static_sharder& sharder, dht::token start, dht::token end, size_t shard_idx) {
     if (start < end) { // Not a wrap around token range
         return find_first_token_for_shard_in_not_wrap_around_range(sharder, start, end, shard_idx);
     } else { // A wrap around token range

--- a/docs/dev/topology-over-raft.md
+++ b/docs/dev/topology-over-raft.md
@@ -302,10 +302,15 @@ stateDiagram-v2
     revert_migration --> [*]
 ```
 
-When tablet is not in transition, the following invariants hold:
+Invariants:
 
-1. The storage layer (database) on any node contains writes for keys which belong to the tablet only if
-    that shard is one of the current tablet replicas.
+1. [INV-TABL-1] When tablet is not in transition, the storage layer (database) on any node contains writes for keys which
+    belong to the tablet only if that shard is one of the current tablet replicas.
+    During transition, previous replicas may contain writes.
+
+2. [INV-TABL-2] There is at most one transition per tablet happening at a time in the cluster. Operations started
+   on behalf of previous transitions can still run in the cluster, but they can have no side effects. This is ensured
+   by the proper use of the topology guard mechanism (see the "Topology guards" section).
 
 # Tablet splitting
 
@@ -347,6 +352,55 @@ doubling tablet count would interfere with the migration process. When the state
 migration track, then finalize can proceed and split each preexisting tablet into two in the topology
 metadata. The replicas  will react to that by remapping its compaction groups into a new set which size
 is equal to the new tablet count.
+
+# Sharding with tablets
+
+Each table can have different shard assignment for a given token computed from the placement of tablet replicas,
+from table's tablet_map.
+
+Generic code should not use static sharders, which only work with vnode-based tables. So it should not use
+schema::get_sharder() or dht::static_shard_of(). It should use erm::get_sharder() instead:
+
+    table& t;
+    auto erm = t.erm();
+    dht::sharder& sharder = erm->get_sharder(); // valid as long as erm is alive
+
+A sharder obtained from effective_replication_map reflects the tablet_map in that particular version of topology.
+
+Since effective_replication_map_ptr blocks topology barriers, it should not be held for long. If the
+code is long-running but doesn't need to work with a particular topology version, it should use auto_refreshing_sharder.
+It is a sharder implementation which automatically switches to the latest effective_replication_map_ptr of the table when it changes.
+
+   dht::auto_refreshing_sharder sharder(table.shared_from_this());
+
+If you use auto_refreshing_sharder, the results of sharder methods may be invalid after preemption point,
+since effective_replication_map instance used to obtain the results may no longer be alive. This
+means that operations which use such a sharder may escape from topology barrier and not be waited for.
+Such users should ensure that barriers synchronize with those operations in some other ways, for
+example by using the topology guard mechanism.
+
+## Tracking replica-side requests
+
+Do I have to hold effective_replication_map_ptr around reading on the replica side?
+
+No, it's enough that coordinator side holds it. If the coordinator side is no longer there,
+there are no consequences to that read, so waiting for the read is not necessary.
+
+Do I have to hold to effective_replication_map_ptr around writing on the replica side?
+
+Yes. Topology coordinator needs to wait for all writes to a tablet replica before cleaning it up to uphold [INV-TABL-1].
+Holding on to effective_replication_map_ptr on the coordinator side is not enough since the coordinator may
+already time-out or restart.
+
+Alternatively, if the writes are done on behalf of a topology operation (e.g. tablet migration), it's enough to use
+the topology guard mechanism, and hold the guard around writes instead of effective_replication_map_ptr.
+
+## Important differences from the static sharding
+
+Unlike with static sharding, shards for a given key can change during node's life time.
+This happens on tablet migration.
+
+Unlike with static sharding, consecutive tokens are not owned by consecutive shards (modulo shard count).
 
 # Topology guards
 

--- a/docs/dev/topology-over-raft.md
+++ b/docs/dev/topology-over-raft.md
@@ -434,6 +434,19 @@ cause discrepancy between coordinator-side decisions and replica-side decisions.
 Also, due to fencing and barriers, coordinator-side version may be behind the replica-side version by at most one
 stage transition. It may also be ahead of the replica-side version by at most one stage transition.
 
+## Tablet replica placement vs sharding
+
+There is a distinction between tablet replica placement on given shard and the shard used for routing requests.
+A shard may be a replica of a tablet, but dht::sharder may not consider this shard for reads or writes yet.
+
+For example, in allow_write_both_read_old stage, the pending replica is not used by the sharder for reads or writes yet.
+The purpose of the stage is to ensure that tablet replica is prepared for receiving requests before any coordinator
+routes requests to it. Similarly, when migration ends, requests stop being routed to the leaving replica before
+tablet replica is cleaned up. So sharder may not return that shard for reads or writes but it still may be a replica of a tablet.
+
+In general, dht::sharder is used for routing requests, so it should not be used to determine whether local shard
+is a replica of a tablet. This is determined by tablet_map::has_replica().
+
 # Topology guards
 
 In addition to synchronizing with data access operations (e.g. CQL requests), we need to synchronize with

--- a/docs/dev/topology-over-raft.md
+++ b/docs/dev/topology-over-raft.md
@@ -383,7 +383,7 @@ Reads and writes may use different shards on a given host during intra-node tabl
 replica acts as a coordinator for writes, which should respect the write replica set selector.
 This selector is reflected in the set of shards returned by the sharder. But since the selectors for reads
 may be different than for writes, the sharder provides separate methods for reads and writes. Reads should
-use sharder::shard_of(), while writes should use sharder::shard_for_writes().
+use sharder::shard_for_reads(), while writes should use sharder::shard_for_writes().
 
 ## Tracking replica-side requests
 

--- a/docs/dev/topology-over-raft.md
+++ b/docs/dev/topology-over-raft.md
@@ -379,6 +379,12 @@ means that operations which use such a sharder may escape from topology barrier 
 Such users should ensure that barriers synchronize with those operations in some other ways, for
 example by using the topology guard mechanism.
 
+Reads and writes may use different shards on a given host during intra-node tablet migration. Local
+replica acts as a coordinator for writes, which should respect the write replica set selector.
+This selector is reflected in the set of shards returned by the sharder. But since the selectors for reads
+may be different than for writes, the sharder provides separate methods for reads and writes. Reads should
+use sharder::shard_of(), while writes should use sharder::shard_for_writes().
+
 ## Tracking replica-side requests
 
 Do I have to hold effective_replication_map_ptr around reading on the replica side?
@@ -401,6 +407,32 @@ Unlike with static sharding, shards for a given key can change during node's lif
 This happens on tablet migration.
 
 Unlike with static sharding, consecutive tokens are not owned by consecutive shards (modulo shard count).
+
+## Shard assignment stability
+
+When tablet is not in transition, each host may contain at most one tablet replica, so there is a single shard for a given
+token and tablet sharder returns that shard, or shard 0 if there is no replica (for consistency with the current API).
+
+The sharder reports a given shard to be the owning shard for a given token as long as either the previous or next
+replica set has replica on that shard.
+
+This is necessary regardless of what the current read or write selectors in the tablet_transition_info
+are. The coordinator may use a different version of effective_replication_map. It may route read request to the leaving
+replica when the leaving replica already sees the write_both_read_new stage. The read should still be served successfully
+from the leaving tablet replica. Because of that, sharder responses should be stable throughout transition as to not
+cause discrepancy between the coordinator-side view of topology and the replica-side view.
+During transitions which are not intra-node migrations the coordinator decisions about target replica set may vary,
+affected by read and write selectors, but replica-side decisions about shard ownership are constant.
+
+Intra-node migration is the opposite. Coordinator-side decisions are constant but replica-side decisions of the sharder vary.
+A node may have two shard-replicas for a given token, but it's enough to read from one of them. The sharder returns the
+replica based on the current read selector. Similarly for writes, the sharder returns the set of owning shards based
+on the current write selector. It may return either the previous shard, the next shard, or both.
+Since coordinator decisions are not affected by stage changes during intra-node migration, this instability doesn't
+cause discrepancy between coordinator-side decisions and replica-side decisions.
+
+Also, due to fencing and barriers, coordinator-side version may be behind the replica-side version by at most one
+stage transition. It may also be ahead of the replica-side version by at most one stage transition.
 
 # Topology guards
 

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -264,8 +264,17 @@ public:
     // Note: must be called after token_metadata has been initialized.
     virtual dht::token_range_vector get_ranges(inet_address ep) const = 0;
 
+    [[deprecated("Use shard_for_reads()/shard_for_writes()")]]
     shard_id shard_of(const schema& s, dht::token t) const {
-        return get_sharder(s).shard_of(t);
+        return shard_for_reads(s, t);
+    }
+
+    shard_id shard_for_reads(const schema& s, dht::token t) const {
+        return get_sharder(s).shard_for_reads(t);
+    }
+
+    dht::shard_replica_set shard_for_writes(const schema& s, dht::token t) const {
+        return get_sharder(s).shard_for_writes(t);
     }
 };
 

--- a/locator/abstract_replication_strategy.hh
+++ b/locator/abstract_replication_strategy.hh
@@ -264,11 +264,6 @@ public:
     // Note: must be called after token_metadata has been initialized.
     virtual dht::token_range_vector get_ranges(inet_address ep) const = 0;
 
-    [[deprecated("Use shard_for_reads()/shard_for_writes()")]]
-    shard_id shard_of(const schema& s, dht::token t) const {
-        return shard_for_reads(s, t);
-    }
-
     shard_id shard_for_reads(const schema& s, dht::token t) const {
         return get_sharder(s).shard_for_reads(t);
     }

--- a/locator/load_sketch.hh
+++ b/locator/load_sketch.hh
@@ -12,6 +12,7 @@
 #include "locator/token_metadata.hh"
 #include "locator/tablets.hh"
 #include "utils/stall_free.hh"
+#include "utils/extremum_tracking.hh"
 #include "utils/div_ceil.hh"
 
 #include <seastar/core/smp.hh>
@@ -140,6 +141,18 @@ public:
         }
         auto& n = _nodes.at(node);
         return div_ceil(n.load(), n._shards.size());
+    }
+
+    // Returns the difference in tablet count between highest-loaded shard and lowest-loaded shard.
+    // Returns 0 when shards are perfectly balanced.
+    // Returns 1 when shards are imbalanced, but it's not possible to balance them.
+    uint64_t get_shard_imbalance(host_id node) const {
+        auto& n = _nodes.at(node);
+        min_max_tracker<uint64_t> minmax;
+        for (auto&& s : n._shards) {
+            minmax.update(s.load);
+        }
+        return minmax.max() - minmax.max();
     }
 };
 

--- a/locator/tablet_sharder.hh
+++ b/locator/tablet_sharder.hh
@@ -29,6 +29,74 @@ private:
             _tmap = &_tm.tablets().get_tablet_map(_table);
         }
     }
+
+    std::optional<unsigned> get_shard(const tablet_replica_set& replicas, host_id host) const {
+        for (auto&& r : replicas) {
+            if (r.host == host) {
+                return r.shard;
+            }
+        }
+        return std::nullopt;
+    };
+
+    dht::shard_replica_set shard_for_writes(tablet_id tid, host_id host) const {
+        auto* trinfo = _tmap->get_tablet_transition_info(tid);
+        auto& tinfo = _tmap->get_tablet_info(tid);
+        dht::shard_replica_set shards;
+
+        auto push_from = [&](const tablet_replica_set& replicas) {
+            for (auto&& r: replicas) {
+                if (r.host == host) {
+                    shards.push_back(r.shard);
+                }
+            }
+        };
+
+        // See "Shard assignment stability" from doc/dev/topology-over-raft.md for explanation of logic.
+
+        if (trinfo && trinfo->pending_replica && trinfo->pending_replica->host == host) {
+            if (trinfo->transition == tablet_transition_kind::intranode_migration) {
+                switch (trinfo->writes) {
+                    case write_replica_set_selector::both:
+                        shards.push_back(trinfo->pending_replica->shard);
+                        [[fallthrough]];
+                    case write_replica_set_selector::previous:
+                        push_from(tinfo.replicas);
+                        break;
+                    case write_replica_set_selector::next:
+                        shards.push_back(trinfo->pending_replica->shard);
+                        break;
+                }
+            } else {
+                shards.push_back(trinfo->pending_replica->shard);
+            }
+        } else {
+            push_from(tinfo.replicas);
+        }
+
+        return shards;
+    }
+
+    std::optional<shard_id> shard_for_reads(tablet_id tid, host_id host) const {
+        ensure_tablet_map();
+        auto* trinfo = _tmap->get_tablet_transition_info(tid);
+        auto& tinfo = _tmap->get_tablet_info(tid);
+
+        if (!trinfo) {
+            return get_shard(tinfo.replicas, host);
+        }
+
+        // See "Shard assignment stability" from doc/dev/topology-over-raft.md for explanation of logic.
+
+        if (trinfo->pending_replica && trinfo->pending_replica->host == host) {
+            if (trinfo->transition == tablet_transition_kind::intranode_migration && trinfo->reads == read_replica_set_selector::previous) {
+                return get_shard(tinfo.replicas, host);
+            }
+            return trinfo->pending_replica->shard;
+        }
+
+        return get_shard(tinfo.replicas, host);
+    }
 public:
     tablet_sharder(const token_metadata& tm, table_id table)
             : _tm(tm)
@@ -37,12 +105,20 @@ public:
 
     virtual ~tablet_sharder() = default;
 
-    virtual unsigned shard_of(const dht::token& token) const override {
+    virtual unsigned shard_of(const dht::token& t) const override {
         ensure_tablet_map();
-        auto tid = _tmap->get_tablet_id(token);
-        auto shard = _tmap->get_shard(tid, _tm.get_my_id());
-        tablet_logger.trace("[{}] shard_of({}) = {}, tablet={}", _table, token, shard, tid);
-        return shard.value_or(0);
+        auto tid = _tmap->get_tablet_id(t);
+        auto shard = shard_for_reads(tid, _tm.get_my_id()).value_or(0);
+        tablet_logger.trace("[{}] shard_of({}) = {}, tablet={}", _table, t, shard, tid);
+        return shard;
+    }
+
+    virtual dht::shard_replica_set shard_for_writes(const token& t) const override {
+        ensure_tablet_map();
+        auto tid = _tmap->get_tablet_id(t);
+        auto shards = shard_for_writes(tid, _tm.get_my_id());
+        tablet_logger.trace("[{}] shard_for_writes({}) = {}, tablet={}", _table, t, shards, tid);
+        return shards;
     }
 
     virtual std::optional<dht::shard_and_token> next_shard(const token& t) const override {
@@ -50,7 +126,7 @@ public:
         auto me = _tm.get_my_id();
         std::optional<tablet_id> tb = _tmap->get_tablet_id(t);
         while ((tb = _tmap->next_tablet(*tb))) {
-            auto r = _tmap->get_shard(*tb, me);
+            auto r = shard_for_reads(*tb, me);
             auto next = _tmap->get_first_token(*tb);
             tablet_logger.trace("[{}] token_for_next_shard({}) = {{{}, {}}}, tablet={}", _table, t, next, r, *tb);
             return dht::shard_and_token{r.value_or(0), next};

--- a/locator/tablet_sharder.hh
+++ b/locator/tablet_sharder.hh
@@ -40,7 +40,7 @@ private:
         return std::nullopt;
     };
 
-    dht::shard_replica_set shard_for_writes(tablet_id tid, host_id host) const {
+    dht::shard_replica_set shard_for_writes(tablet_id tid, host_id host, std::optional<write_replica_set_selector> sel = std::nullopt) const {
         auto* trinfo = _tmap->get_tablet_transition_info(tid);
         auto& tinfo = _tmap->get_tablet_info(tid);
         dht::shard_replica_set shards;
@@ -57,7 +57,7 @@ private:
 
         if (trinfo && trinfo->pending_replica && trinfo->pending_replica->host == host) {
             if (trinfo->transition == tablet_transition_kind::intranode_migration) {
-                switch (trinfo->writes) {
+                switch (sel.value_or(trinfo->writes)) {
                     case write_replica_set_selector::both:
                         shards.push_back(trinfo->pending_replica->shard);
                         [[fallthrough]];
@@ -115,10 +115,10 @@ public:
         return shard;
     }
 
-    virtual dht::shard_replica_set shard_for_writes(const token& t) const override {
+    virtual dht::shard_replica_set shard_for_writes(const token& t, std::optional<write_replica_set_selector> sel = std::nullopt) const override {
         ensure_tablet_map();
         auto tid = _tmap->get_tablet_id(t);
-        auto shards = shard_for_writes(tid, _host);
+        auto shards = shard_for_writes(tid, _host, sel);
         tablet_logger.trace("[{}] shard_for_writes({}) = {}, tablet={}", _table, t, shards, tid);
         return shards;
     }

--- a/locator/tablet_sharder.hh
+++ b/locator/tablet_sharder.hh
@@ -107,7 +107,7 @@ public:
 
     virtual ~tablet_sharder() = default;
 
-    virtual unsigned shard_of(const dht::token& t) const override {
+    virtual unsigned shard_for_reads(const token& t) const override {
         ensure_tablet_map();
         auto tid = _tmap->get_tablet_id(t);
         auto shard = shard_for_reads(tid, _host).value_or(0);
@@ -123,7 +123,7 @@ public:
         return shards;
     }
 
-    virtual std::optional<dht::shard_and_token> next_shard(const token& t) const override {
+    virtual std::optional<dht::shard_and_token> next_shard_for_reads(const token& t) const override {
         ensure_tablet_map();
         std::optional<tablet_id> tb = _tmap->get_tablet_id(t);
         while ((tb = _tmap->next_tablet(*tb))) {
@@ -136,10 +136,10 @@ public:
         return std::nullopt;
     }
 
-    virtual token token_for_next_shard(const token& t, shard_id shard, unsigned spans = 1) const override {
+    virtual token token_for_next_shard_for_reads(const token& t, shard_id shard, unsigned spans = 1) const override {
         ensure_tablet_map();
         auto token = t;
-        while (auto s_a_t = next_shard(token)) {
+        while (auto s_a_t = next_shard_for_reads(token)) {
             token = s_a_t->token;
             if (s_a_t->shard == shard) {
                 if (--spans == 0) {

--- a/locator/tablet_sharder.hh
+++ b/locator/tablet_sharder.hh
@@ -21,6 +21,7 @@ class tablet_sharder : public dht::sharder {
     const token_metadata& _tm;
     table_id _table;
     mutable const tablet_map* _tmap = nullptr;
+    host_id _host;
 private:
     // Tablet map is lazily initialized to avoid exceptions during effective_replication_map construction
     // in case tablet mapping is not yet available in token metadata at the time the table is constructed.
@@ -98,9 +99,10 @@ private:
         return get_shard(tinfo.replicas, host);
     }
 public:
-    tablet_sharder(const token_metadata& tm, table_id table)
+    tablet_sharder(const token_metadata& tm, table_id table, std::optional<host_id> host = std::nullopt)
             : _tm(tm)
             , _table(table)
+            , _host(host.value_or(tm.get_my_id()))
     { }
 
     virtual ~tablet_sharder() = default;
@@ -108,7 +110,7 @@ public:
     virtual unsigned shard_of(const dht::token& t) const override {
         ensure_tablet_map();
         auto tid = _tmap->get_tablet_id(t);
-        auto shard = shard_for_reads(tid, _tm.get_my_id()).value_or(0);
+        auto shard = shard_for_reads(tid, _host).value_or(0);
         tablet_logger.trace("[{}] shard_of({}) = {}, tablet={}", _table, t, shard, tid);
         return shard;
     }
@@ -116,17 +118,16 @@ public:
     virtual dht::shard_replica_set shard_for_writes(const token& t) const override {
         ensure_tablet_map();
         auto tid = _tmap->get_tablet_id(t);
-        auto shards = shard_for_writes(tid, _tm.get_my_id());
+        auto shards = shard_for_writes(tid, _host);
         tablet_logger.trace("[{}] shard_for_writes({}) = {}, tablet={}", _table, t, shards, tid);
         return shards;
     }
 
     virtual std::optional<dht::shard_and_token> next_shard(const token& t) const override {
         ensure_tablet_map();
-        auto me = _tm.get_my_id();
         std::optional<tablet_id> tb = _tmap->get_tablet_id(t);
         while ((tb = _tmap->next_tablet(*tb))) {
-            auto r = shard_for_reads(*tb, me);
+            auto r = shard_for_reads(*tb, _host);
             auto next = _tmap->get_first_token(*tb);
             tablet_logger.trace("[{}] token_for_next_shard({}) = {{{}, {}}}, tablet={}", _table, t, next, r, *tb);
             return dht::shard_and_token{r.value_or(0), next};

--- a/locator/tablets.cc
+++ b/locator/tablets.cc
@@ -100,6 +100,8 @@ tablet_migration_streaming_info get_migration_streaming_info(const locator::topo
 tablet_migration_streaming_info get_migration_streaming_info(const locator::topology& topo, const tablet_info& tinfo, const tablet_transition_info& trinfo) {
     tablet_migration_streaming_info result;
     switch (trinfo.transition) {
+        case tablet_transition_kind::intranode_migration:
+            [[fallthrough]];
         case tablet_transition_kind::migration:
             result.read_from = substract_sets(tinfo.replicas, trinfo.next);
             result.written_to = substract_sets(trinfo.next, tinfo.replicas);
@@ -346,6 +348,7 @@ tablet_transition_stage tablet_transition_stage_from_string(const sstring& name)
 // The names are persisted in system tables so should not be changed.
 static const std::unordered_map<tablet_transition_kind, sstring> tablet_transition_kind_to_name = {
         {tablet_transition_kind::migration, "migration"},
+        {tablet_transition_kind::intranode_migration, "intranode_migration"},
         {tablet_transition_kind::rebuild, "rebuild"},
 };
 
@@ -633,7 +636,7 @@ public:
         auto&& tablets = get_tablet_map();
         auto tablet = tablets.get_tablet_id(search_token);
         auto&& info = tablets.get_tablet_transition_info(tablet);
-        if (!info) {
+        if (!info || info->transition == tablet_transition_kind::intranode_migration) {
             return {};
         }
         switch (info->writes) {

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -382,11 +382,9 @@ public:
         return tablet_id(size_t(t) + 1);
     }
 
-    /// Returns shard id which is a replica for a given tablet on a given host.
-    /// If there is no replica on a given host, returns nullopt.
-    /// If the topology is transitional, also considers the new replica set.
-    /// The old replica set is preferred in case of ambiguity.
-    std::optional<shard_id> get_shard(tablet_id, host_id) const;
+    /// Returns true iff tablet has a given replica.
+    /// If tablet is in transition, considers both previous and next replica set.
+    bool has_replica(tablet_id, tablet_replica) const;
 
     const tablet_container& tablets() const {
         return _tablets;

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -13,6 +13,7 @@
 #include "locator/host_id.hh"
 #include "service/session.hh"
 #include "dht/i_partitioner_fwd.hh"
+#include "dht/token-sharding.hh"
 #include "dht/ring_position.hh"
 #include "schema/schema_fwd.hh"
 #include "utils/chunked_vector.hh"
@@ -191,9 +192,7 @@ tablet_transition_stage tablet_transition_stage_from_string(const sstring&);
 sstring tablet_transition_kind_to_string(tablet_transition_kind);
 tablet_transition_kind tablet_transition_kind_from_string(const sstring&);
 
-enum class write_replica_set_selector {
-    previous, both, next
-};
+using write_replica_set_selector = dht::write_replica_set_selector;
 
 enum class read_replica_set_selector {
     previous, next

--- a/locator/tablets.hh
+++ b/locator/tablets.hh
@@ -177,6 +177,9 @@ enum class tablet_transition_kind {
     // The leaving replica is (tablet_info::replicas - tablet_transition_info::next).
     migration,
 
+    // Like migration, but the new pending replica is on the same host as leaving replica.
+    intranode_migration,
+
     // New tablet replica is replacing a dead one.
     // The new replica is (tablet_transition_info::next - tablet_info::replicas).
     // The leaving replica is (tablet_info::replicas - tablet_transition_info::next).

--- a/multishard_mutation_query.cc
+++ b/multishard_mutation_query.cc
@@ -428,7 +428,7 @@ read_context::dismantle_buffer_stats read_context::dismantle_combined_buffer(fla
     const auto rend = std::reverse_iterator(combined_buffer.begin());
     for (;rit != rend; ++rit) {
         if (rit->is_partition_start()) {
-            const auto shard = sharder.shard_of(rit->as_partition_start().key().token());
+            const auto shard = sharder.shard_for_reads(rit->as_partition_start().key().token());
 
             // It is possible that the reader this partition originates from
             // does not exist anymore. Either because we failed stopping it or
@@ -455,7 +455,7 @@ read_context::dismantle_buffer_stats read_context::dismantle_combined_buffer(fla
         }
     }
 
-    const auto shard = sharder.shard_of(pkey.token());
+    const auto shard = sharder.shard_for_reads(pkey.token());
     auto& shard_buffer = _readers[shard].get_dismantled_buffer(_permit);
     for (auto& smf : tmp_buffer) {
         stats.add(smf);
@@ -468,7 +468,7 @@ read_context::dismantle_buffer_stats read_context::dismantle_combined_buffer(fla
 read_context::dismantle_buffer_stats read_context::dismantle_compaction_state(detached_compaction_state compaction_state) {
     auto stats = dismantle_buffer_stats();
     auto& sharder = _erm->get_sharder(*_schema);
-    const auto shard = sharder.shard_of(compaction_state.partition_start.key().token());
+    const auto shard = sharder.shard_for_reads(compaction_state.partition_start.key().token());
 
     auto& rtc_opt = compaction_state.current_tombstone;
 

--- a/mutation_writer/multishard_writer.cc
+++ b/mutation_writer/multishard_writer.cc
@@ -47,13 +47,14 @@ private:
     std::vector<foreign_ptr<std::unique_ptr<shard_writer>>> _shard_writers;
     std::vector<future<>> _pending_consumers;
     std::vector<std::optional<queue_reader_handle_v2>> _queue_reader_handles;
-    unsigned _current_shard = -1;
+    dht::shard_replica_set _current_shards;
     uint64_t _consumed_partitions = 0;
     flat_mutation_reader_v2 _producer;
     std::function<future<> (flat_mutation_reader_v2)> _consumer;
 private:
-    unsigned shard_for_mf(const mutation_fragment_v2& mf) {
-        return _sharder.shard_of(mf.as_partition_start().key().token());
+    dht::shard_replica_set shard_for_mf(const mutation_fragment_v2& mf) {
+        auto token = mf.as_partition_start().key().token();
+        return _sharder.shard_for_writes(token);
     }
     future<> make_shard_writer(unsigned shard);
     future<stop_iteration> handle_mutation_fragment(mutation_fragment_v2 mf);
@@ -131,16 +132,25 @@ future<stop_iteration> multishard_writer::handle_mutation_fragment(mutation_frag
     auto f = make_ready_future<>();
     if (mf.is_partition_start()) {
         _consumed_partitions++;
-        if (unsigned shard = shard_for_mf(mf); shard != _current_shard) {
-            _current_shard = shard;
-            if (!bool(_shard_writers[shard])) {
-                f = make_shard_writer(shard);
+        if (auto shards = shard_for_mf(mf); shards != _current_shards) {
+            _current_shards = shards;
+            for (auto shard : shards) {
+                if (!bool(_shard_writers[shard])) {
+                    f = f.then([this, shard] {
+                        return make_shard_writer(shard);
+                    });
+                }
             }
         }
     }
     return f.then([this, mf = std::move(mf)] () mutable {
-        assert(_current_shard != -1u);
-        return _queue_reader_handles[_current_shard]->push(std::move(mf));
+        assert(!_current_shards.empty());
+        if (_current_shards.size() == 1) [[likely]] {
+            return _queue_reader_handles[_current_shards[0]]->push(std::move(mf));
+        }
+        return seastar::parallel_for_each(_current_shards, [this, mf = std::move(mf)] (unsigned shard) {
+            return _queue_reader_handles[shard]->push(mutation_fragment_v2(*_s, mf.permit(), mf));
+        });
     }).then([] {
         return stop_iteration::no;
     });

--- a/readers/multishard.cc
+++ b/readers/multishard.cc
@@ -1010,7 +1010,7 @@ void multishard_combining_reader_v2::on_partition_range_change(const dht::partit
     _shard_selection_min_heap.reserve(_sharder.shard_count());
 
     auto token = pr.start() ? pr.start()->value().token() : dht::minimum_token();
-    _current_shard = _sharder.shard_of(token);
+    _current_shard = _sharder.shard_for_reads(token);
 
     auto sharder = dht::ring_position_range_sharder(_sharder, pr);
 

--- a/repair/reader.hh
+++ b/repair/reader.hh
@@ -51,7 +51,7 @@ public:
         schema_ptr s,
         reader_permit permit,
         dht::token_range range,
-        const dht::sharder& remote_sharder,
+        const dht::static_sharder& remote_sharder,
         unsigned remote_shard,
         uint64_t seed,
         read_strategy strategy,

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -338,7 +338,7 @@ repair_reader::repair_reader(
     schema_ptr s,
     reader_permit permit,
     dht::token_range range,
-    const dht::sharder& remote_sharder,
+    const dht::static_sharder& remote_sharder,
     unsigned remote_shard,
     uint64_t seed,
     read_strategy strategy,
@@ -752,7 +752,7 @@ private:
     // Repair master's sharding configuration
     shard_config _master_node_shard_config;
     // sharding info of repair master
-    dht::sharder _remote_sharder;
+    dht::static_sharder _remote_sharder;
     bool _same_sharding_config = false;
     struct local_range_estimation {
         size_t master_subranges_count;
@@ -1077,8 +1077,8 @@ private:
         });
     }
 
-    dht::sharder make_remote_sharder() {
-        return dht::sharder(_master_node_shard_config.shard_count, _master_node_shard_config.ignore_msb);
+    dht::static_sharder make_remote_sharder() {
+        return dht::static_sharder(_master_node_shard_config.shard_count, _master_node_shard_config.ignore_msb);
     }
 
     bool is_same_sharding_config(replica::column_family& cf) {

--- a/repair/row_level.cc
+++ b/repair/row_level.cc
@@ -323,7 +323,7 @@ flat_mutation_reader_v2 repair_reader::make_reader(
             _permit.release_base_resources();
             return make_filtering_reader(make_multishard_streaming_reader(db, _schema, _permit, _range, compaction_time),
                 [&remote_sharder, remote_shard](const dht::decorated_key& k) {
-                    return remote_sharder.shard_of(k.token()) == remote_shard;
+                    return remote_sharder.shard_for_reads(k.token()) == remote_shard;
                 });
         }
         default:

--- a/replica/compaction_group.hh
+++ b/replica/compaction_group.hh
@@ -223,6 +223,9 @@ public:
 
     // Make an sstable set spanning all sstables in the storage_group
     lw_shared_ptr<sstables::sstable_set> make_sstable_set() const;
+
+    // Flush all memtables.
+    future<> flush() noexcept;
 };
 
 using storage_group_map = absl::flat_hash_map<size_t, std::unique_ptr<storage_group>, absl::Hash<size_t>>;

--- a/replica/database.cc
+++ b/replica/database.cc
@@ -76,6 +76,8 @@
 #include "readers/multi_range.hh"
 #include "readers/multishard.hh"
 
+#include <algorithm>
+
 using namespace std::chrono_literals;
 using namespace db;
 
@@ -1909,7 +1911,6 @@ future<> database::apply(const std::vector<frozen_mutation>& muts, db::timeout_c
 future<> database::do_apply_many(const std::vector<frozen_mutation>& muts, db::timeout_clock::time_point timeout) {
     std::vector<commitlog_entry_writer> writers;
     db::commitlog* cl = nullptr;
-    std::optional<shard_id> shard;
 
     if (muts.empty()) {
         co_return;
@@ -1930,14 +1931,9 @@ future<> database::do_apply_many(const std::vector<frozen_mutation>& muts, db::t
                               first_cf.schema()->ks_name(), first_cf.schema()->cf_name()));
         }
 
-        auto m_shard = cf.shard_of(dht::get_token(*s, muts[i].key()));
-        if (!shard) {
-            if (this_shard_id() != m_shard) {
-                on_internal_error(dblog, format("Must call apply() on the owning shard ({} != {})", this_shard_id(), m_shard));
-            }
-            shard = m_shard;
-        } else if (*shard != m_shard) {
-            on_internal_error(dblog, "Cannot apply atomically across shards");
+        auto m_shards = cf.shard_for_writes(dht::get_token(*s, muts[i].key()));
+        if (std::ranges::find(m_shards, this_shard_id()) == std::ranges::end(m_shards)) {
+            on_internal_error(dblog, format("Must call apply() on the owning shard ({} not in {})", this_shard_id(), m_shards));
         }
 
         dblog.trace("apply [{}/{}]: {}", i, muts.size() - 1, muts[i].pretty_printer(s));

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -102,6 +102,7 @@ class compaction_data;
 class sstable_set;
 class directory_semaphore;
 struct sstable_files_snapshot;
+struct entry_descriptor;
 
 }
 
@@ -1221,6 +1222,10 @@ public:
     // all compaction groups that overlap with a given token range. The output is
     // a list of SSTables that represent the snapshot.
     future<utils::chunked_vector<sstables::sstable_files_snapshot>> take_storage_snapshot(dht::token_range tr);
+
+    // Clones storage of a given tablet. Memtable is flushed first to guarantee that the
+    // snapshot (list of sstables) will include all the data written up to the time it was taken.
+    future<utils::chunked_vector<sstables::entry_descriptor>> clone_tablet_storage(locator::tablet_id tid);
 
     friend class compaction_group;
 };

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -841,10 +841,6 @@ public:
     future<> cleanup_tablet(database&, db::system_keyspace&, locator::tablet_id);
     future<const_mutation_partition_ptr> find_partition(schema_ptr, reader_permit permit, const dht::decorated_key& key) const;
     future<const_row_ptr> find_row(schema_ptr, reader_permit permit, const dht::decorated_key& partition_key, clustering_key clustering_key) const;
-    [[deprecated("Use shard_for_reads()/shard_for_writes()")]]
-    shard_id shard_of(const mutation& m) const;
-    [[deprecated("Use shard_for_reads()/shard_for_writes()")]]
-    shard_id shard_of(dht::token t) const { return shard_for_reads(t); }
     shard_id shard_for_reads(dht::token t) const;
     dht::shard_replica_set shard_for_writes(dht::token t) const;
     // Applies given mutation to this column family

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -1351,7 +1351,7 @@ class db_user_types_storage;
 // Policy for distributed<database>:
 //   broadcast metadata writes
 //   local metadata reads
-//   use shard_of() for data
+//   use table::shard_for_reads()/table::shard_for_writes() for data
 
 class database : public peering_sharded_service<database> {
     friend class ::database_test;

--- a/replica/database.hh
+++ b/replica/database.hh
@@ -841,13 +841,12 @@ public:
     future<> cleanup_tablet(database&, db::system_keyspace&, locator::tablet_id);
     future<const_mutation_partition_ptr> find_partition(schema_ptr, reader_permit permit, const dht::decorated_key& key) const;
     future<const_row_ptr> find_row(schema_ptr, reader_permit permit, const dht::decorated_key& partition_key, clustering_key clustering_key) const;
-    shard_id shard_of(const mutation& m) const {
-        return shard_of(m.token());
-    }
-    shard_id shard_of(dht::token t) const {
-        return _erm ? _erm->shard_of(*_schema, t)
-                    : dht::static_shard_of(*_schema, t); // for tests.
-    }
+    [[deprecated("Use shard_for_reads()/shard_for_writes()")]]
+    shard_id shard_of(const mutation& m) const;
+    [[deprecated("Use shard_for_reads()/shard_for_writes()")]]
+    shard_id shard_of(dht::token t) const { return shard_for_reads(t); }
+    shard_id shard_for_reads(dht::token t) const;
+    dht::shard_replica_set shard_for_writes(dht::token t) const;
     // Applies given mutation to this column family
     // The mutation is always upgraded to current schema.
     void apply(const frozen_mutation& m, const schema_ptr& m_schema, db::rp_handle&& h = {}) {

--- a/replica/mutation_dump.cc
+++ b/replica/mutation_dump.cc
@@ -404,7 +404,7 @@ future<flat_mutation_reader_v2> make_partition_mutation_dump_reader(
         tracing::trace_state_ptr ts,
         db::timeout_clock::time_point timeout) {
     const auto& tbl = db.local().find_column_family(underlying_schema);
-    const auto shard = tbl.shard_of(dk.token());
+    const auto shard = tbl.shard_for_reads(dk.token());
     if (shard == this_shard_id()) {
         co_return make_flat_mutation_reader_v2<mutation_dump_reader>(std::move(output_schema), std::move(underlying_schema), std::move(permit),
                 db.local(), dk, ps, std::move(ts));

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -106,11 +106,6 @@ table::make_sstable_reader(schema_ptr s,
     // consequence, fast_forward_to() will *NOT* work on the result,
     // regardless of what the fwd_mr parameter says.
     if (pr.is_singular() && pr.start()->value().has_key()) {
-        const dht::ring_position& pos = pr.start()->value();
-        if (_erm->shard_of(*s, pos.token()) != this_shard_id()) {
-            return make_empty_flat_reader_v2(s, std::move(permit)); // range doesn't belong to this shard
-        }
-
         return sstables->create_single_key_sstable_reader(const_cast<column_family*>(this), std::move(s), std::move(permit),
                 _stats.estimated_sstable_per_read, pr, slice, std::move(trace_state), fwd, fwd_mr, predicate);
     } else {

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -996,6 +996,21 @@ future<utils::chunked_vector<sstables::sstable_files_snapshot>> table::take_stor
     co_return std::move(ret);
 }
 
+future<utils::chunked_vector<sstables::entry_descriptor>>
+table::clone_tablet_storage(locator::tablet_id tid) {
+    utils::chunked_vector<sstables::entry_descriptor> ret;
+    auto holder = async_gate().hold();
+    // FIXME: guard storage group with shared lock.
+
+    auto* sg = storage_group_for_id(tid.value());
+    co_await sg->flush();
+    auto set = sg->make_sstable_set();
+    co_await set->for_each_sstable_gently([this, &ret] (const sstables::shared_sstable& sst) -> future<> {
+        ret.push_back(co_await sst->clone(calculate_generation_for_new_table()));
+    });
+    co_return ret;
+}
+
 void table::update_stats_for_new_sstable(const sstables::shared_sstable& sst) noexcept {
     _stats.live_disk_space_used += sst->bytes_on_disk();
     _stats.total_disk_space_used += sst->bytes_on_disk();
@@ -2409,6 +2424,12 @@ future<> compaction_group::flush() noexcept {
         return _memtables->flush();
     } catch (...) {
         return current_exception_as_future<>();
+    }
+}
+
+future<> storage_group::flush() noexcept {
+    for (auto& cg : compaction_groups()) {
+        co_await cg->flush();
     }
 }
 

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -3436,10 +3436,6 @@ future<> table::cleanup_tablet(database& db, db::system_keyspace& sys_ks, locato
     // FIXME: Deallocate compaction group in this shard
 }
 
-shard_id table::shard_of(const mutation& m) const {
-    return shard_of(m.token());
-}
-
 shard_id table::shard_for_reads(dht::token t) const {
     return _erm ? _erm->shard_for_reads(*_schema, t)
                 : dht::static_shard_of(*_schema, t); // for tests.

--- a/replica/table.cc
+++ b/replica/table.cc
@@ -3441,4 +3441,18 @@ future<> table::cleanup_tablet(database& db, db::system_keyspace& sys_ks, locato
     // FIXME: Deallocate compaction group in this shard
 }
 
+shard_id table::shard_of(const mutation& m) const {
+    return shard_of(m.token());
+}
+
+shard_id table::shard_for_reads(dht::token t) const {
+    return _erm ? _erm->shard_for_reads(*_schema, t)
+                : dht::static_shard_of(*_schema, t); // for tests.
+}
+
+dht::shard_replica_set table::shard_for_writes(dht::token t) const {
+    return _erm ? _erm->shard_for_writes(*_schema, t)
+                : dht::shard_replica_set{dht::static_shard_of(*_schema, t)}; // for tests.
+}
+
 } // namespace replica

--- a/schema/schema.hh
+++ b/schema/schema.hh
@@ -37,6 +37,7 @@ namespace dht {
 
 class i_partitioner;
 class sharder;
+class static_sharder;
 
 }
 
@@ -605,7 +606,7 @@ private:
         std::reference_wrapper<const dht::i_partitioner> _partitioner;
         // Sharding info is not stored in the schema mutation and does not affect
         // schema digest. It is also not set locally on a schema tables.
-        std::reference_wrapper<const dht::sharder> _sharder;
+        std::reference_wrapper<const dht::static_sharder> _sharder;
     };
     raw_schema _raw;
     schema_static_props _static_props;
@@ -792,11 +793,11 @@ public:
     // Use only for tables which use vnode-based replication strategy, that is for which
     // table::uses_static_sharding() is true.
     // To obtain a sharder which is valid for all kinds of tables, use table::get_effective_replication_map()->get_sharder()
-    const dht::sharder& get_sharder() const;
+    const dht::static_sharder& get_sharder() const;
 
     // Returns a sharder for this table, but only if it is a static sharder (token->shard mappings
     // don't change while the node is up)
-    const dht::sharder* try_get_static_sharder() const;
+    const dht::static_sharder* try_get_static_sharder() const;
 
     // Returns a pointer to the table if the local database has a table which this object references by id().
     // The table pointer is not guaranteed to be stable, schema_ptr doesn't keep the table alive.

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -3099,7 +3099,9 @@ future<>
 storage_proxy::mutate_counter_on_leader_and_replicate(const schema_ptr& s, frozen_mutation fm, db::consistency_level cl, clock_type::time_point timeout,
                                                       tracing::trace_state_ptr trace_state, service_permit permit) {
     auto erm = _db.local().find_column_family(s).get_effective_replication_map();
-    auto shard = erm->get_sharder(*s).shard_of(fm.token(*s));
+    // FIXME: This does not handle intra-node tablet migration properly.
+    // Refs https://github.com/scylladb/scylladb/issues/18180
+    auto shard = erm->get_sharder(*s).shard_for_reads(fm.token(*s));
     bool local = shard == this_shard_id();
     get_stats().replica_cross_shard_ops += !local;
     return _db.invoke_on(shard, {_write_smp_service_group, timeout}, [&proxy = container(), gs = global_schema_ptr(s), fm = std::move(fm), cl, timeout, gt = tracing::global_trace_state_ptr(std::move(trace_state)), permit = std::move(permit), local] (replica::database& db) {

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -841,7 +841,7 @@ private:
         return get_schema_for_read(cmd.schema_version, src_addr, *timeout).then([&sp = _sp, &sys_ks = _sys_ks, cmd = std::move(cmd), key = std::move(key), ballot,
                          only_digest, da, timeout, tr_state = std::move(tr_state), src_ip] (schema_ptr schema) mutable {
             dht::token token = dht::get_token(*schema, key);
-            unsigned shard = schema->table().shard_of(token);
+            unsigned shard = schema->table().shard_for_reads(token);
             bool local = shard == this_shard_id();
             sp.get_stats().replica_cross_shard_ops += !local;
             return sp.container().invoke_on(shard, sp._write_smp_service_group, [gs = global_schema_ptr(schema), gt = tracing::global_trace_state_ptr(std::move(tr_state)),
@@ -871,7 +871,7 @@ private:
         auto f = get_schema_for_read(proposal.update.schema_version(), src_addr, *timeout).then([&sp = _sp, &sys_ks = _sys_ks, tr_state = std::move(tr_state),
                                                               proposal = std::move(proposal), timeout] (schema_ptr schema) mutable {
             dht::token token = proposal.update.decorated_key(*schema).token();
-            unsigned shard = schema->table().shard_of(token);
+            unsigned shard = schema->table().shard_for_reads(token);
             bool local = shard == this_shard_id();
             sp.get_stats().replica_cross_shard_ops += !local;
             return sp.container().invoke_on(shard, sp._write_smp_service_group, [gs = global_schema_ptr(schema), gt = tracing::global_trace_state_ptr(std::move(tr_state)),
@@ -914,7 +914,7 @@ private:
         return get_schema_for_read(schema_id, src_addr, *timeout).then([&sp = _sp, &sys_ks = _sys_ks, key = std::move(key), ballot,
                          timeout, tr_state = std::move(tr_state), src_ip, d = std::move(d)] (schema_ptr schema) mutable {
             dht::token token = dht::get_token(*schema, key);
-            unsigned shard = schema->table().shard_of(token);
+            unsigned shard = schema->table().shard_for_reads(token);
             bool local = shard == this_shard_id();
             sp.get_stats().replica_cross_shard_ops += !local;
             return smp::submit_to(shard, sp._write_smp_service_group, [gs = global_schema_ptr(schema), gt = tracing::global_trace_state_ptr(std::move(tr_state)),
@@ -952,7 +952,7 @@ const dht::token& end_token(const dht::partition_range& r) {
 }
 
 unsigned storage_proxy::cas_shard(const schema& s, dht::token token) {
-    return s.table().shard_of(token);
+    return s.table().shard_for_reads(token);
 }
 
 static uint32_t random_variable_for_rate_limit() {

--- a/service/storage_proxy.cc
+++ b/service/storage_proxy.cc
@@ -2964,29 +2964,48 @@ storage_proxy::response_id_type storage_proxy::unique_response_handler::release(
 future<>
 storage_proxy::mutate_locally(const mutation& m, tracing::trace_state_ptr tr_state, db::commitlog::force_sync sync, clock_type::time_point timeout, smp_service_group smp_grp, db::per_partition_rate_limit::info rate_limit_info) {
     auto erm = _db.local().find_column_family(m.schema()).get_effective_replication_map();
-    auto shard = erm->get_sharder(*m.schema()).shard_of(m.token());
-    get_stats().replica_cross_shard_ops += shard != this_shard_id();
-    return _db.invoke_on(shard, {smp_grp, timeout},
-            [s = global_schema_ptr(m.schema()),
-             m = freeze(m),
-             gtr = tracing::global_trace_state_ptr(std::move(tr_state)),
-             timeout,
-             sync,
-             rate_limit_info] (replica::database& db) mutable -> future<> {
-        return db.apply(s, m, gtr.get(), sync, timeout, rate_limit_info);
-    });
+    auto shards = erm->get_sharder(*m.schema()).shard_for_writes(m.token());
+    if (shards.empty()) {
+        throw std::runtime_error(format("No local shards for token {} of {}.{}", m.token(), m.schema()->ks_name(), m.schema()->cf_name()));
+    }
+    auto apply = [this, erm, &m, tr_state, sync, timeout, smp_grp, rate_limit_info] (shard_id shard) {
+        get_stats().replica_cross_shard_ops += shard != this_shard_id();
+        return _db.invoke_on(shard, {smp_grp, timeout},
+                [s = global_schema_ptr(m.schema()),
+                 m = freeze(m),
+                 gtr = tracing::global_trace_state_ptr(std::move(tr_state)),
+                 erm,
+                 timeout,
+                 sync,
+                 rate_limit_info] (replica::database& db) mutable -> future<> {
+            return db.apply(s, m, gtr.get(), sync, timeout, rate_limit_info);
+        });
+    };
+    if (shards.size() == 1) [[likely]] {
+        return apply(shards[0]);
+    }
+    return seastar::parallel_for_each(shards, std::move(apply));
 }
 
 future<>
 storage_proxy::mutate_locally(const schema_ptr& s, const frozen_mutation& m, tracing::trace_state_ptr tr_state, db::commitlog::force_sync sync, clock_type::time_point timeout,
         smp_service_group smp_grp, db::per_partition_rate_limit::info rate_limit_info) {
     auto erm = _db.local().find_column_family(s).get_effective_replication_map();
-    auto shard = erm->get_sharder(*s).shard_of(m.token(*s));
-    get_stats().replica_cross_shard_ops += shard != this_shard_id();
-    return _db.invoke_on(shard, {smp_grp, timeout},
-            [&m, gs = global_schema_ptr(s), gtr = tracing::global_trace_state_ptr(std::move(tr_state)), timeout, sync, rate_limit_info] (replica::database& db) mutable -> future<> {
-        return db.apply(gs, m, gtr.get(), sync, timeout, rate_limit_info);
-    });
+    auto shards = erm->get_sharder(*s).shard_for_writes(m.token(*s));
+    if (shards.empty()) {
+        throw std::runtime_error(format("No local shards for token {} of {}.{}", m.token(*s), s->ks_name(), s->cf_name()));
+    }
+    auto apply = [this, erm, s, &m, tr_state, sync, timeout, smp_grp, rate_limit_info] (shard_id shard) {
+        get_stats().replica_cross_shard_ops += shard != this_shard_id();
+        return _db.invoke_on(shard, {smp_grp, timeout},
+                [&m, erm, gs = global_schema_ptr(s), gtr = tracing::global_trace_state_ptr(std::move(tr_state)), timeout, sync, rate_limit_info] (replica::database& db) mutable -> future<> {
+            return db.apply(gs, m, gtr.get(), sync, timeout, rate_limit_info);
+        });
+    };
+    if (shards.size() == 1) [[likely]] {
+        return apply(shards[0]);
+    }
+    return seastar::parallel_for_each(shards, std::move(apply));
 }
 
 future<>

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5658,6 +5658,7 @@ future<> storage_service::stream_tablet(locator::global_tablet_id tablet) {
         streaming::stream_reason reason = std::invoke([&] {
             switch (trinfo->transition) {
                 case locator::tablet_transition_kind::migration: return streaming::stream_reason::tablet_migration;
+                case locator::tablet_transition_kind::intranode_migration: return streaming::stream_reason::tablet_migration;
                 case locator::tablet_transition_kind::rebuild: return streaming::stream_reason::rebuild;
                 default:
                     throw std::runtime_error(fmt::format("stream_tablet(): Invalid tablet transition: {}", trinfo->transition));

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -71,6 +71,7 @@
 #include "supervisor.hh"
 #include "compaction/compaction_manager.hh"
 #include "sstables/sstables.hh"
+#include "sstables/sstables_manager.hh"
 #include "db/config.hh"
 #include "db/schema_tables.hh"
 #include "replica/database.hh"
@@ -5617,6 +5618,48 @@ future<> storage_service::do_tablet_operation(locator::global_tablet_id tablet,
     }
 }
 
+future<> storage_service::clone_locally_tablet_storage(locator::global_tablet_id tablet, locator::tablet_replica leaving, locator::tablet_replica pending) {
+    if (leaving.host != pending.host) {
+        throw std::runtime_error(fmt::format("Leaving and pending tablet replicas belong to different nodes, {} and {} respectively",
+                                             leaving.host, pending.host));
+    }
+
+    auto d = co_await smp::submit_to(leaving.shard, [this, tablet] () -> future<utils::chunked_vector<sstables::entry_descriptor>> {
+        auto& table = _db.local().find_column_family(tablet.table);
+        auto op = table.stream_in_progress();
+        co_return co_await table.clone_tablet_storage(tablet.tablet);
+    });
+    rtlogger.debug("Cloned storage of tablet {} from leaving replica {}, {} sstables were found", tablet, leaving, d.size());
+
+    auto load_sstable = [] (const dht::sharder& sharder, replica::table& t, sstables::entry_descriptor d) -> future<sstables::shared_sstable> {
+        auto& mng = t.get_sstables_manager();
+        auto sst = mng.make_sstable(t.schema(), t.dir(), t.get_storage_options(), d.generation, d.state.value_or(sstables::sstable_state::normal),
+                                    d.version, d.format, gc_clock::now(), default_io_error_handler_gen());
+        // The loader will consider current shard as sstable owner, despite the tablet sharder
+        // will still point to leaving replica at this stage in migration. If node goes down,
+        // SSTables will be loaded at pending replica and migration is retried, so correctness
+        // wise, we're good.
+        auto cfg = sstables::sstable_open_config{ .current_shard_as_sstable_owner = true };
+        co_await sst->load(sharder, cfg);
+        co_return sst;
+    };
+
+    co_await smp::submit_to(pending.shard, [this, tablet, load_sstable, d = std::move(d)] () mutable -> future<> {
+        // Loads cloned sstables from leaving replica into pending one.
+        auto& table = _db.local().find_column_family(tablet.table);
+        auto op = table.stream_in_progress();
+        dht::auto_refreshing_sharder sharder(table.shared_from_this());
+
+        std::vector<sstables::shared_sstable> ssts;
+        ssts.reserve(d.size());
+        for (auto&& sst_desc : d) {
+            ssts.push_back(co_await load_sstable(sharder, table, std::move(sst_desc)));
+        }
+        co_await table.add_sstables_and_update_cache(ssts);
+    });
+    rtlogger.debug("Successfully loaded storage of tablet {} into pending replica {}", tablet, pending);
+}
+
 // Streams data to the pending tablet replica of a given tablet on this node.
 // The source tablet replica is determined from the current transition info of the tablet.
 future<> storage_service::stream_tablet(locator::global_tablet_id tablet) {
@@ -5665,20 +5708,10 @@ future<> storage_service::stream_tablet(locator::global_tablet_id tablet) {
                 throw std::runtime_error(fmt::format("Invalid leaving replica for intra-node migration, tablet: {}, leaving: {}",
                                                      tablet, leaving_replica));
             }
-            auto range = to_partition_range(tmap.get_token_range(tablet.tablet));
             tm = nullptr;
-            co_await smp::submit_to(leaving_replica->shard, [this, tablet, pending_replica, reason, topo_guard, range] () -> future<> {
-                rtlogger.info("Starting intra-node streaming of tablet {} to shard {}", tablet, pending_replica->shard);
-                auto& table = _db.local().find_column_family(tablet.table);
-                dht::auto_refreshing_sharder sharder(table.shared_from_this(), dht::write_replica_set_selector::next);
-                auto estimated_partitions = 1; // FIXME
-                auto permit = co_await _db.local().obtain_reader_permit(table, "stream-session", db::no_timeout, {});
-                co_await mutation_writer::distribute_reader_and_consume_on_shards(table.schema(), sharder,
-                    table.make_streaming_reader(table.schema(), std::move(permit), range, gc_clock::now()),
-                    _stream_manager.local().make_streaming_consumer(estimated_partitions, reason, topo_guard),
-                    table.stream_in_progress());
-                rtlogger.info("Intra-node tablet streaming of {} finished", tablet, pending_replica->shard);
-            });
+            rtlogger.info("Starting intra-node streaming of tablet {} from shard {} to {}", tablet, leaving_replica->shard, pending_replica->shard);
+            co_await clone_locally_tablet_storage(tablet, *leaving_replica, *pending_replica);
+            rtlogger.info("Finished intra-node streaming of tablet {} from shard {} to {}", tablet, leaving_replica->shard, pending_replica->shard);
         } else {
             if (leaving_replica && leaving_replica->host == tm->get_my_id()) {
                 throw std::runtime_error(fmt::format("Cannot stream within the same node using regular migration, tablet: {}, shard {} -> {}",

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5811,11 +5811,13 @@ future<> storage_service::move_tablet(table_id table, dht::token token, locator:
         if (dst.shard >= node->get_shard_count()) {
             throw std::runtime_error(format("Host {} does not have shard {}", *node, dst.shard));
         }
-        if (src.host == dst.host) {
-            throw std::runtime_error("Migrating within the same node is not supported");
+
+        if (src == dst) {
+            sstring reason = format("No-op move of tablet {} to {}", gid, dst);
+            return std::make_tuple(std::move(updates), std::move(reason));
         }
 
-        if (locator::contains(tinfo.replicas, dst.host)) {
+        if (src.host != dst.host && locator::contains(tinfo.replicas, dst.host)) {
             throw std::runtime_error(fmt::format("Tablet {} has replica on {}", gid, dst.host));
         }
         auto src_dc_rack = get_token_metadata().get_topology().get_location(src.host);
@@ -5838,7 +5840,8 @@ future<> storage_service::move_tablet(table_id table, dht::token token, locator:
         updates.emplace_back(replica::tablet_mutation_builder(write_timestamp, table)
             .set_new_replicas(last_token, locator::replace_replica(tinfo.replicas, src, dst))
             .set_stage(last_token, locator::tablet_transition_stage::allow_write_both_read_old)
-            .set_transition(last_token, locator::tablet_transition_kind::migration)
+            .set_transition(last_token, src.host == dst.host ? locator::tablet_transition_kind::intranode_migration
+                                                             : locator::tablet_transition_kind::migration)
             .build());
 
         sstring reason = format("Moving tablet {} from {} to {}", gid, src, dst);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -6099,6 +6099,27 @@ future<> storage_service::set_tablet_balancing_enabled(bool enabled) {
     }
 }
 
+future<> storage_service::await_topology_quiesced() {
+    auto holder = _async_gate.hold();
+
+    if (this_shard_id() != 0) {
+        // group0 is only set on shard 0.
+        co_await container().invoke_on(0, [&] (auto& ss) {
+            return ss.await_topology_quiesced();
+        });
+        co_return;
+    }
+
+    group0_guard guard = co_await _group0->client().start_operation(&_group0_as, raft_timeout{});
+
+    while (_topology_state_machine._topology.is_busy()) {
+        rtlogger.debug("await_topology_quiesced(): topology is busy");
+        release_guard(std::move(guard));
+        co_await _topology_state_machine.event.wait();
+        guard = co_await _group0->client().start_operation(&_group0_as, raft_timeout{});
+    }
+}
+
 future<join_node_request_result> storage_service::join_node_request_handler(join_node_request_params params) {
     join_node_request_result result;
     rtlogger.info("received request to join from host_id: {}", params.host_id);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -5735,6 +5735,7 @@ future<> storage_service::cleanup_tablet(locator::global_tablet_id tablet) {
                 if (leaving_replica->host != tm->get_my_id()) {
                     throw std::runtime_error(fmt::format("Tablet {} has leaving replica different than this one", tablet));
                 }
+                shard = leaving_replica->shard;
             } else if (trinfo->stage == locator::tablet_transition_stage::cleanup_target) {
                 if (!trinfo->pending_replica) {
                     throw std::runtime_error(fmt::format("Tablet {} has no pending replica", tablet));
@@ -5742,15 +5743,10 @@ future<> storage_service::cleanup_tablet(locator::global_tablet_id tablet) {
                 if (trinfo->pending_replica->host != tm->get_my_id()) {
                     throw std::runtime_error(fmt::format("Tablet {} has pending replica different than this one", tablet));
                 }
+                shard = trinfo->pending_replica->shard;
             } else {
                 throw std::runtime_error(fmt::format("Tablet {} stage is not at cleanup/cleanup_target", tablet));
             }
-
-            auto shard_opt = tmap.get_shard(tablet.tablet, tm->get_my_id());
-            if (!shard_opt) {
-                on_internal_error(rtlogger, format("Tablet {} has no shard on this node", tablet));
-            }
-            shard = *shard_opt;
         }
         return _db.invoke_on(shard, [tablet, &sys_ks = _sys_ks] (replica::database& db) {
             auto& table = db.find_column_family(tablet.table);

--- a/service/storage_service.cc
+++ b/service/storage_service.cc
@@ -36,6 +36,8 @@
 #include "service/tablet_allocator.hh"
 #include "locator/types.hh"
 #include "locator/tablets.hh"
+#include "dht/auto_refreshing_sharder.hh"
+#include "mutation_writer/multishard_writer.hh"
 #include "locator/tablet_metadata_guard.hh"
 #include "replica/tablet_mutation_builder.hh"
 #include <seastar/core/smp.hh>
@@ -5646,13 +5648,6 @@ future<> storage_service::stream_tablet(locator::global_tablet_id tablet) {
         auto& tinfo = tmap.get_tablet_info(tablet.tablet);
         auto range = tmap.get_token_range(tablet.tablet);
         std::optional<locator::tablet_replica> leaving_replica = locator::get_leaving_replica(tinfo, *trinfo);
-        if (leaving_replica && leaving_replica->host == tm->get_my_id()) {
-            // The algorithm doesn't work with tablet migration within the same node because
-            // it assumes there is only one tablet replica, picked by the sharder, on local node.
-            throw std::runtime_error(fmt::format("Cannot stream within the same node, tablet: {}, shard {} -> {}",
-                                            tablet, leaving_replica->shard, pending_replica->shard));
-        }
-
         locator::tablet_migration_streaming_info streaming_info = get_migration_streaming_info(tm->get_topology(), tinfo, *trinfo);
 
         streaming::stream_reason reason = std::invoke([&] {
@@ -5665,26 +5660,51 @@ future<> storage_service::stream_tablet(locator::global_tablet_id tablet) {
             }
         });
 
-        auto& table = _db.local().find_column_family(tablet.table);
-        std::vector<sstring> tables = {table.schema()->cf_name()};
-        auto my_id = tm->get_my_id();
-        auto streamer = make_lw_shared<dht::range_streamer>(_db, _stream_manager, std::move(tm),
-                                                            guard.get_abort_source(),
-                                                            my_id, _snitch.local()->get_location(),
-                                                            format("Tablet {}", trinfo->transition),
-                                                            reason,
-                                                            topo_guard,
-                                                            std::move(tables));
-        tm = nullptr;
-        streamer->add_source_filter(std::make_unique<dht::range_streamer::failure_detector_source_filter>(
-                _gossiper.get_unreachable_members()));
+        if (trinfo->transition == locator::tablet_transition_kind::intranode_migration) {
+            if (!leaving_replica || leaving_replica->host != tm->get_my_id()) {
+                throw std::runtime_error(fmt::format("Invalid leaving replica for intra-node migration, tablet: {}, leaving: {}",
+                                                     tablet, leaving_replica));
+            }
+            auto range = to_partition_range(tmap.get_token_range(tablet.tablet));
+            tm = nullptr;
+            co_await smp::submit_to(leaving_replica->shard, [this, tablet, pending_replica, reason, topo_guard, range] () -> future<> {
+                rtlogger.info("Starting intra-node streaming of tablet {} to shard {}", tablet, pending_replica->shard);
+                auto& table = _db.local().find_column_family(tablet.table);
+                dht::auto_refreshing_sharder sharder(table.shared_from_this(), dht::write_replica_set_selector::next);
+                auto estimated_partitions = 1; // FIXME
+                auto permit = co_await _db.local().obtain_reader_permit(table, "stream-session", db::no_timeout, {});
+                co_await mutation_writer::distribute_reader_and_consume_on_shards(table.schema(), sharder,
+                    table.make_streaming_reader(table.schema(), std::move(permit), range, gc_clock::now()),
+                    _stream_manager.local().make_streaming_consumer(estimated_partitions, reason, topo_guard),
+                    table.stream_in_progress());
+                rtlogger.info("Intra-node tablet streaming of {} finished", tablet, pending_replica->shard);
+            });
+        } else {
+            if (leaving_replica && leaving_replica->host == tm->get_my_id()) {
+                throw std::runtime_error(fmt::format("Cannot stream within the same node using regular migration, tablet: {}, shard {} -> {}",
+                                                     tablet, leaving_replica->shard, trinfo->pending_replica->shard));
+            }
+            auto& table = _db.local().find_column_family(tablet.table);
+            std::vector<sstring> tables = {table.schema()->cf_name()};
+            auto my_id = tm->get_my_id();
+            auto streamer = make_lw_shared<dht::range_streamer>(_db, _stream_manager, std::move(tm),
+                                                                guard.get_abort_source(),
+                                                                my_id, _snitch.local()->get_location(),
+                                                                format("Tablet {}", trinfo->transition),
+                                                                reason,
+                                                                topo_guard,
+                                                                std::move(tables));
+            tm = nullptr;
+            streamer->add_source_filter(std::make_unique<dht::range_streamer::failure_detector_source_filter>(
+                    _gossiper.get_unreachable_members()));
 
-        std::unordered_map<inet_address, dht::token_range_vector> ranges_per_endpoint;
-        for (auto r : streaming_info.read_from) {
-            ranges_per_endpoint[host2ip(r.host)].emplace_back(range);
+            std::unordered_map<inet_address, dht::token_range_vector> ranges_per_endpoint;
+            for (auto r: streaming_info.read_from) {
+                ranges_per_endpoint[host2ip(r.host)].emplace_back(range);
+            }
+            streamer->add_rx_ranges(table.schema()->ks_name(), std::move(ranges_per_endpoint));
+            co_await streamer->stream_async();
         }
-        streamer->add_rx_ranges(table.schema()->ks_name(), std::move(ranges_per_endpoint));
-        co_await streamer->stream_async();
 
         // If new pending tablet replica needs splitting, streaming waits for it to complete.
         // That's to provide a guarantee that once migration is over, the coordinator can finalize

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -179,6 +179,9 @@ private:
                                  sstring op_name,
                                  std::function<future<>(locator::tablet_metadata_guard&)> op);
     future<> stream_tablet(locator::global_tablet_id);
+    // Clones storage of leaving tablet into pending one. Done in the context of intra-node migration,
+    // when both of which sit on the same node. So all the movement is local.
+    future<> clone_locally_tablet_storage(locator::global_tablet_id, locator::tablet_replica leaving, locator::tablet_replica pending);
     future<> cleanup_tablet(locator::global_tablet_id);
     inet_address host2ip(locator::host_id) const;
     // Handler for table load stats RPC.

--- a/service/storage_service.hh
+++ b/service/storage_service.hh
@@ -862,6 +862,7 @@ public:
     future<> add_tablet_replica(table_id, dht::token, locator::tablet_replica dst, loosen_constraints force = loosen_constraints::no);
     future<> del_tablet_replica(table_id, dht::token, locator::tablet_replica dst, loosen_constraints force = loosen_constraints::no);
     future<> set_tablet_balancing_enabled(bool);
+    future<> await_topology_quiesced();
 
     // In the maintenance mode, other nodes won't be available thus we disabled joining
     // the token ring and the token metadata won't be populated with the local node's endpoint.

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -1084,7 +1084,8 @@ public:
                                            || src_info.state() == locator::node::state::left)
                        ? tablet_transition_kind::rebuild : tablet_transition_kind::migration;
             auto mig = tablet_migration_info {kind, source_tablet, src, dst};
-            auto mig_streaming_info = get_migration_streaming_info(topo, tmap.get_tablet_info(source_tablet.tablet), mig);
+            auto& src_tinfo = tmap.get_tablet_info(source_tablet.tablet);
+            auto mig_streaming_info = get_migration_streaming_info(topo, src_tinfo, mig);
 
             if (can_accept_load(nodes, mig_streaming_info)) {
                 apply_load(nodes, mig_streaming_info);
@@ -1107,6 +1108,13 @@ public:
                 }
             }
 
+            for (auto&& r : src_tinfo.replicas) {
+                if (nodes.contains(r.host)) {
+                    nodes[r.host].shards[r.shard].candidates.erase(source_tablet);
+                }
+            }
+
+            target_info.shards[dst.shard].tablet_count++;
             target_info.tablet_count += 1;
             target_info.update();
 

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -269,6 +269,9 @@ class load_balancer {
         }
     };
 
+    // Data structure used for making load-balancing decisions over a set of nodes.
+    using node_load_map = std::unordered_map<host_id, node_load>;
+
     // We have split and merge thresholds, which work respectively as (target) upper and lower
     // bound for average size of tablets.
     //
@@ -595,6 +598,43 @@ public:
         co_return std::move(resize_plan);
     }
 
+    void apply_load(node_load_map& nodes, const tablet_migration_streaming_info& info) {
+        for (auto&& replica : info.read_from) {
+            if (nodes.contains(replica.host)) {
+                nodes[replica.host].shards[replica.shard].streaming_read_load += 1;
+            }
+        }
+        for (auto&& replica : info.written_to) {
+            if (nodes.contains(replica.host)) {
+                nodes[replica.host].shards[replica.shard].streaming_write_load += 1;
+            }
+        }
+    }
+
+    bool can_accept_load(node_load_map& nodes, const tablet_migration_streaming_info& info) {
+        for (auto r : info.read_from) {
+            if (!nodes.contains(r.host)) {
+                continue;
+            }
+            auto load = nodes[r.host].shards[r.shard].streaming_read_load;
+            if (load >= max_read_streaming_load) {
+                lblogger.debug("Migration skipped because of read load limit on {} ({})", r, load);
+                return false;
+            }
+        }
+        for (auto r : info.written_to) {
+            if (!nodes.contains(r.host)) {
+                continue;
+            }
+            auto load = nodes[r.host].shards[r.shard].streaming_write_load;
+            if (load >= max_write_streaming_load) {
+                lblogger.debug("Migration skipped because of write load limit on {} ({})", r, load);
+                return false;
+            }
+        }
+        return true;
+    }
+
     future<migration_plan> make_plan(dc_name dc) {
         migration_plan plan;
 
@@ -611,7 +651,7 @@ public:
 
         // Select subset of nodes to balance.
 
-        std::unordered_map<host_id, node_load> nodes;
+        node_load_map nodes;
         std::unordered_set<host_id> nodes_to_drain;
 
         auto ensure_node = [&] (host_id host) {
@@ -767,50 +807,13 @@ public:
 
         // Compute per-shard load and candidate tablets.
 
-        auto apply_load = [&] (const tablet_migration_streaming_info& info) {
-            for (auto&& replica : info.read_from) {
-                if (nodes.contains(replica.host)) {
-                    nodes[replica.host].shards[replica.shard].streaming_read_load += 1;
-                }
-            }
-            for (auto&& replica : info.written_to) {
-                if (nodes.contains(replica.host)) {
-                    nodes[replica.host].shards[replica.shard].streaming_write_load += 1;
-                }
-            }
-        };
-
-        auto can_accept_load = [&] (const tablet_migration_streaming_info& info) {
-            for (auto r : info.read_from) {
-                if (!nodes.contains(r.host)) {
-                    continue;
-                }
-                auto load = nodes[r.host].shards[r.shard].streaming_read_load;
-                if (load >= max_read_streaming_load) {
-                    lblogger.debug("Migration skipped because of read load limit on {} ({})", r, load);
-                    return false;
-                }
-            }
-            for (auto r : info.written_to) {
-                if (!nodes.contains(r.host)) {
-                    continue;
-                }
-                auto load = nodes[r.host].shards[r.shard].streaming_write_load;
-                if (load >= max_write_streaming_load) {
-                    lblogger.debug("Migration skipped because of write load limit on {} ({})", r, load);
-                    return false;
-                }
-            }
-            return true;
-        };
-
         for (auto&& [table, tmap_] : _tm->tablets().all_tables()) {
             auto& tmap = tmap_;
             co_await tmap.for_each_tablet([&, table = table] (tablet_id tid, const tablet_info& ti) -> future<> {
                 auto trinfo = tmap.get_tablet_transition_info(tid);
 
                 if (is_streaming(trinfo)) {
-                    apply_load(get_migration_streaming_info(topo, ti, *trinfo));
+                    apply_load(nodes, get_migration_streaming_info(topo, ti, *trinfo));
                 }
 
                 for (auto&& replica : get_replicas_for_tablet_load(ti, trinfo)) {
@@ -1083,8 +1086,8 @@ public:
             auto mig = tablet_migration_info {kind, source_tablet, src, dst};
             auto mig_streaming_info = get_migration_streaming_info(topo, tmap.get_tablet_info(source_tablet.tablet), mig);
 
-            if (can_accept_load(mig_streaming_info)) {
-                apply_load(mig_streaming_info);
+            if (can_accept_load(nodes, mig_streaming_info)) {
+                apply_load(nodes, mig_streaming_info);
                 lblogger.debug("Adding migration: {}", mig);
                 _stats.for_dc(dc).migrations_produced++;
                 plan.add(std::move(mig));

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -635,205 +635,14 @@ public:
         return true;
     }
 
-    future<migration_plan> make_plan(dc_name dc) {
+    bool in_shuffle_mode() const {
+        return utils::get_local_injector().enter("tablet_allocator_shuffle");
+    }
+
+    future<migration_plan> make_internode_plan(const dc_name& dc, node_load_map& nodes,
+                                               const std::unordered_set<host_id>& nodes_to_drain,
+                                               host_id target) {
         migration_plan plan;
-
-        _stats.for_dc(dc).calls++;
-        lblogger.info("Examining DC {}", dc);
-
-        // Causes load balancer to move some tablet even though load is balanced.
-        auto shuffle = utils::get_local_injector().enter("tablet_allocator_shuffle");
-        if (shuffle) {
-            lblogger.warn("Running without convergence checks");
-        }
-
-        const locator::topology& topo = _tm->get_topology();
-
-        // Select subset of nodes to balance.
-
-        node_load_map nodes;
-        std::unordered_set<host_id> nodes_to_drain;
-
-        auto ensure_node = [&] (host_id host) {
-            if (nodes.contains(host)) {
-                return;
-            }
-            auto* node = topo.find_node(host);
-            if (!node) {
-                on_internal_error(lblogger, format("Node {} not found in topology", host));
-            }
-            node_load& load = nodes[host];
-            load.id = host;
-            load.node = node;
-            load.shard_count = node->get_shard_count();
-            load.shards.resize(load.shard_count);
-            if (!load.shard_count) {
-                throw std::runtime_error(format("Shard count of {} not found in topology", host));
-            }
-        };
-
-        topo.for_each_node([&] (const locator::node* node_ptr) {
-            if (node_ptr->dc_rack().dc != dc) {
-                return;
-            }
-            bool is_drained = node_ptr->get_state() == locator::node::state::being_decommissioned
-                              || node_ptr->get_state() == locator::node::state::being_removed;
-            if (node_ptr->get_state() == locator::node::state::normal || is_drained) {
-                if (is_drained) {
-                    ensure_node(node_ptr->host_id());
-                    lblogger.info("Will drain node {} ({}) from DC {}", node_ptr->host_id(), node_ptr->get_state(), dc);
-                    nodes_to_drain.emplace(node_ptr->host_id());
-                } else if (node_ptr->is_excluded() || _skiplist.contains(node_ptr->host_id())) {
-                    // Excluded nodes should not be chosen as targets for migration.
-                    lblogger.debug("Ignoring excluded or dead node {}: state={}", node_ptr->host_id(), node_ptr->get_state());
-                } else {
-                    ensure_node(node_ptr->host_id());
-                }
-            }
-        });
-
-        // Compute tablet load on nodes.
-
-        for (auto&& [table, tmap_] : _tm->tablets().all_tables()) {
-            auto& tmap = tmap_;
-
-            co_await tmap.for_each_tablet([&, table = table] (tablet_id tid, const tablet_info& ti) -> future<> {
-                auto trinfo = tmap.get_tablet_transition_info(tid);
-
-                // Check if any replica is on a node which has left.
-                // When node is replaced we don't rebuild as part of topology request.
-                for (auto&& r : ti.replicas) {
-                    auto* node = topo.find_node(r.host);
-                    if (!node) {
-                        on_internal_error(lblogger, format("Replica {} of tablet {} not found in topology",
-                                                           r, global_tablet_id{table, tid}));
-                    }
-                    if (node->left() && node->dc_rack().dc == dc) {
-                        ensure_node(r.host);
-                        nodes_to_drain.insert(r.host);
-                    }
-                }
-
-                // We reflect migrations in the load as if they already happened,
-                // optimistically assuming that they will succeed.
-                for (auto&& replica : get_replicas_for_tablet_load(ti, trinfo)) {
-                    if (nodes.contains(replica.host)) {
-                        nodes[replica.host].tablet_count += 1;
-                        // This invariant is assumed later.
-                        if (replica.shard >= nodes[replica.host].shard_count) {
-                            auto gtid = global_tablet_id{table, tid};
-                            on_internal_error(lblogger, format("Tablet {} replica {} targets non-existent shard", gtid, replica));
-                        }
-                    }
-                }
-
-                return make_ready_future<>();
-            });
-        }
-
-        if (nodes.empty()) {
-            lblogger.debug("No nodes to balance.");
-            _stats.for_dc(dc).stop_balance++;
-            co_return plan;
-        }
-
-        // Detect finished drain.
-
-        for (auto i = nodes_to_drain.begin(); i != nodes_to_drain.end();) {
-            if (nodes[*i].tablet_count == 0) {
-                lblogger.info("Node {} is already drained, ignoring", *i);
-                nodes.erase(*i);
-                i = nodes_to_drain.erase(i);
-            } else {
-                ++i;
-            }
-        }
-
-        plan.set_has_nodes_to_drain(!nodes_to_drain.empty());
-
-        // Compute load imbalance.
-
-        load_type max_load = 0;
-        load_type min_load = 0;
-        std::optional<host_id> min_load_node = std::nullopt;
-        for (auto&& [host, load] : nodes) {
-            load.update();
-            _stats.for_node(dc, host).load = load.avg_load;
-
-            if (!nodes_to_drain.contains(host)) {
-                if (!min_load_node || load.avg_load < min_load) {
-                    min_load = load.avg_load;
-                    min_load_node = host;
-                }
-                if (load.avg_load > max_load) {
-                    max_load = load.avg_load;
-                }
-            }
-        }
-
-        for (auto&& [host, load] : nodes) {
-            lblogger.info("Node {}: rack={} avg_load={}, tablets={}, shards={}, state={}",
-                          host, load.rack(), load.avg_load, load.tablet_count, load.shard_count, load.state());
-        }
-
-        if (!min_load_node) {
-            lblogger.debug("No candidate nodes");
-            _stats.for_dc(dc).stop_no_candidates++;
-            co_return plan;
-        }
-
-        if (nodes_to_drain.empty()) {
-            if (!shuffle && (max_load == min_load || !_tm->tablets().balancing_enabled())) {
-                // load is balanced.
-                // TODO: Evaluate and fix intra-node balance.
-                _stats.for_dc(dc).stop_balance++;
-                co_return plan;
-            }
-            lblogger.info("target node: {}, avg_load: {}, max: {}", *min_load_node, min_load, max_load);
-        }
-
-        // We want to saturate the target node so we migrate several tablets in parallel, one for each shard
-        // on the target node. This assumes that the target node is well-balanced and that tablet migrations
-        // complete at the same time. Both assumptions are not generally true in practice, which we currently ignore.
-        // But they will be true typically, because we fill shards starting from least-loaded shards,
-        // so we naturally strive towards balance between shards.
-        //
-        // If target node is not balanced across shards, we will overload some shards. Streaming concurrency
-        // will suffer because more loaded shards will not participate, which will under-utilize the node.
-        // FIXME: To handle the above, we should rebalance the target node before migrating tablets from other nodes.
-
-        auto target = *min_load_node;
-        auto batch_size = nodes[target].shard_count;
-
-        // Compute per-shard load and candidate tablets.
-
-        for (auto&& [table, tmap_] : _tm->tablets().all_tables()) {
-            auto& tmap = tmap_;
-            co_await tmap.for_each_tablet([&, table = table] (tablet_id tid, const tablet_info& ti) -> future<> {
-                auto trinfo = tmap.get_tablet_transition_info(tid);
-
-                if (is_streaming(trinfo)) {
-                    apply_load(nodes, get_migration_streaming_info(topo, ti, *trinfo));
-                }
-
-                for (auto&& replica : get_replicas_for_tablet_load(ti, trinfo)) {
-                    if (!nodes.contains(replica.host)) {
-                        continue;
-                    }
-                    auto& node_load_info = nodes[replica.host];
-                    shard_load& shard_load_info = node_load_info.shards[replica.shard];
-                    if (shard_load_info.tablet_count == 0) {
-                        node_load_info.shards_by_load.push_back(replica.shard);
-                    }
-                    shard_load_info.tablet_count += 1;
-                    if (!trinfo) { // migrating tablets are not candidates
-                        shard_load_info.candidates.emplace(global_tablet_id {table, tid});
-                    }
-                }
-
-                return make_ready_future<>();
-            });
-        }
 
         // Prepare candidate nodes and shards for heap-based balancing.
 
@@ -880,9 +689,12 @@ public:
         std::make_heap(nodes_by_load_dst.begin(), nodes_by_load_dst.end(), nodes_dst_cmp);
 
         const tablet_metadata& tmeta = _tm->tablets();
+        const locator::topology& topo = _tm->get_topology();
         load_type max_off_candidate_load = 0; // max load among nodes which ran out of candidates.
+        auto batch_size = nodes[target].shard_count;
         const size_t max_skipped_migrations = nodes[target].shards.size() * 2;
         size_t skipped_migrations = 0;
+        auto shuffle = in_shuffle_mode();
         while (plan.size() < batch_size) {
             co_await coroutine::maybe_yield();
 
@@ -1151,6 +963,204 @@ public:
             // So node3 will have average load of 1, and node1 and node2 will have
             // average shard load of 7.
             lblogger.info("Not possible to achieve balance.");
+        }
+
+        co_return std::move(plan);
+    }
+
+    future<migration_plan> make_plan(dc_name dc) {
+        migration_plan plan;
+
+        _stats.for_dc(dc).calls++;
+        lblogger.info("Examining DC {}", dc);
+
+        // Causes load balancer to move some tablet even though load is balanced.
+        auto shuffle = in_shuffle_mode();
+        if (shuffle) {
+            lblogger.warn("Running without convergence checks");
+        }
+
+        const locator::topology& topo = _tm->get_topology();
+
+        // Select subset of nodes to balance.
+
+        node_load_map nodes;
+        std::unordered_set<host_id> nodes_to_drain;
+
+        auto ensure_node = [&] (host_id host) {
+            if (nodes.contains(host)) {
+                return;
+            }
+            auto* node = topo.find_node(host);
+            if (!node) {
+                on_internal_error(lblogger, format("Node {} not found in topology", host));
+            }
+            node_load& load = nodes[host];
+            load.id = host;
+            load.node = node;
+            load.shard_count = node->get_shard_count();
+            load.shards.resize(load.shard_count);
+            if (!load.shard_count) {
+                throw std::runtime_error(format("Shard count of {} not found in topology", host));
+            }
+        };
+
+        topo.for_each_node([&] (const locator::node* node_ptr) {
+            if (node_ptr->dc_rack().dc != dc) {
+                return;
+            }
+            bool is_drained = node_ptr->get_state() == locator::node::state::being_decommissioned
+                              || node_ptr->get_state() == locator::node::state::being_removed;
+            if (node_ptr->get_state() == locator::node::state::normal || is_drained) {
+                if (is_drained) {
+                    ensure_node(node_ptr->host_id());
+                    lblogger.info("Will drain node {} ({}) from DC {}", node_ptr->host_id(), node_ptr->get_state(), dc);
+                    nodes_to_drain.emplace(node_ptr->host_id());
+                } else if (node_ptr->is_excluded() || _skiplist.contains(node_ptr->host_id())) {
+                    // Excluded nodes should not be chosen as targets for migration.
+                    lblogger.debug("Ignoring excluded or dead node {}: state={}", node_ptr->host_id(), node_ptr->get_state());
+                } else {
+                    ensure_node(node_ptr->host_id());
+                }
+            }
+        });
+
+        // Compute tablet load on nodes.
+
+        for (auto&& [table, tmap_] : _tm->tablets().all_tables()) {
+            auto& tmap = tmap_;
+
+            co_await tmap.for_each_tablet([&, table = table] (tablet_id tid, const tablet_info& ti) -> future<> {
+                auto trinfo = tmap.get_tablet_transition_info(tid);
+
+                // Check if any replica is on a node which has left.
+                // When node is replaced we don't rebuild as part of topology request.
+                for (auto&& r : ti.replicas) {
+                    auto* node = topo.find_node(r.host);
+                    if (!node) {
+                        on_internal_error(lblogger, format("Replica {} of tablet {} not found in topology",
+                                                           r, global_tablet_id{table, tid}));
+                    }
+                    if (node->left() && node->dc_rack().dc == dc) {
+                        ensure_node(r.host);
+                        nodes_to_drain.insert(r.host);
+                    }
+                }
+
+                // We reflect migrations in the load as if they already happened,
+                // optimistically assuming that they will succeed.
+                for (auto&& replica : get_replicas_for_tablet_load(ti, trinfo)) {
+                    if (nodes.contains(replica.host)) {
+                        nodes[replica.host].tablet_count += 1;
+                        // This invariant is assumed later.
+                        if (replica.shard >= nodes[replica.host].shard_count) {
+                            auto gtid = global_tablet_id{table, tid};
+                            on_internal_error(lblogger, format("Tablet {} replica {} targets non-existent shard", gtid, replica));
+                        }
+                    }
+                }
+
+                return make_ready_future<>();
+            });
+        }
+
+        if (nodes.empty()) {
+            lblogger.debug("No nodes to balance.");
+            _stats.for_dc(dc).stop_balance++;
+            co_return plan;
+        }
+
+        // Detect finished drain.
+
+        for (auto i = nodes_to_drain.begin(); i != nodes_to_drain.end();) {
+            if (nodes[*i].tablet_count == 0) {
+                lblogger.info("Node {} is already drained, ignoring", *i);
+                nodes.erase(*i);
+                i = nodes_to_drain.erase(i);
+            } else {
+                ++i;
+            }
+        }
+
+        plan.set_has_nodes_to_drain(!nodes_to_drain.empty());
+
+        // Compute load imbalance.
+
+        load_type max_load = 0;
+        load_type min_load = 0;
+        std::optional<host_id> min_load_node = std::nullopt;
+        for (auto&& [host, load] : nodes) {
+            load.update();
+            _stats.for_node(dc, host).load = load.avg_load;
+
+            if (!nodes_to_drain.contains(host)) {
+                if (!min_load_node || load.avg_load < min_load) {
+                    min_load = load.avg_load;
+                    min_load_node = host;
+                }
+                if (load.avg_load > max_load) {
+                    max_load = load.avg_load;
+                }
+            }
+        }
+
+        for (auto&& [host, load] : nodes) {
+            lblogger.info("Node {}: rack={} avg_load={}, tablets={}, shards={}, state={}",
+                          host, load.rack(), load.avg_load, load.tablet_count, load.shard_count, load.state());
+        }
+
+        if (!min_load_node) {
+            lblogger.debug("No candidate nodes");
+            _stats.for_dc(dc).stop_no_candidates++;
+            co_return plan;
+        }
+
+        // We want to saturate the target node so we migrate several tablets in parallel, one for each shard
+        // on the target node. This assumes that the target node is well-balanced and that tablet migrations
+        // complete at the same time. Both assumptions are not generally true in practice, which we currently ignore.
+        // But they will be true typically, because we fill shards starting from least-loaded shards,
+        // so we naturally strive towards balance between shards.
+        //
+        // If target node is not balanced across shards, we will overload some shards. Streaming concurrency
+        // will suffer because more loaded shards will not participate, which will under-utilize the node.
+        // FIXME: To handle the above, we should rebalance the target node before migrating tablets from other nodes.
+
+        // Compute per-shard load and candidate tablets.
+
+        for (auto&& [table, tmap_] : _tm->tablets().all_tables()) {
+            auto& tmap = tmap_;
+            co_await tmap.for_each_tablet([&, table = table] (tablet_id tid, const tablet_info& ti) -> future<> {
+                auto trinfo = tmap.get_tablet_transition_info(tid);
+
+                if (is_streaming(trinfo)) {
+                    apply_load(nodes, get_migration_streaming_info(topo, ti, *trinfo));
+                }
+
+                for (auto&& replica : get_replicas_for_tablet_load(ti, trinfo)) {
+                    if (!nodes.contains(replica.host)) {
+                        continue;
+                    }
+                    auto& node_load_info = nodes[replica.host];
+                    shard_load& shard_load_info = node_load_info.shards[replica.shard];
+                    if (shard_load_info.tablet_count == 0) {
+                        node_load_info.shards_by_load.push_back(replica.shard);
+                    }
+                    shard_load_info.tablet_count += 1;
+                    if (!trinfo) { // migrating tablets are not candidates
+                        shard_load_info.candidates.emplace(global_tablet_id {table, tid});
+                    }
+                }
+
+                return make_ready_future<>();
+            });
+        }
+
+        if (!nodes_to_drain.empty() || shuffle || (max_load != min_load && _tm->tablets().balancing_enabled())) {
+            host_id target = *min_load_node;
+            lblogger.info("target node: {}, avg_load: {}, max: {}", target, min_load, max_load);
+            plan.merge(co_await make_internode_plan(dc, nodes, nodes_to_drain, target));
+        } else {
+            _stats.for_dc(dc).stop_balance++;
         }
 
         co_await utils::clear_gently(nodes);

--- a/service/tablet_allocator.cc
+++ b/service/tablet_allocator.cc
@@ -29,6 +29,7 @@ seastar::logger lblogger("load_balancer");
 struct load_balancer_dc_stats {
     uint64_t calls = 0;
     uint64_t migrations_produced = 0;
+    uint64_t intranode_migrations_produced = 0;
     uint64_t migrations_skipped = 0;
     uint64_t tablets_skipped_node = 0;
     uint64_t tablets_skipped_rack = 0;
@@ -153,7 +154,7 @@ public:
 /// to them so that we can distribute load equally without overloading shards which are out of balance,
 /// but this is not implemented yet.
 ///
-/// The outline of the algorithm is as follows:
+/// The outline of the inter-node balancing algorithm is as follows:
 ///
 ///   1. Determine the set of nodes whose load should be balanced.
 ///   2. Pick the least-loaded node (target)
@@ -177,6 +178,13 @@ public:
 /// convergence checks, and the stop condition is that the source is drained. We still take target
 /// load into consideration and pick least-loaded targets first. When draining is not possible
 /// because there is no viable new replica for a tablet, load balancing will throw an exception.
+///
+/// After scheduling inter-node migrations, the algorithm schedules intra-node migrations.
+/// This means that across-node migrations can proceed in parallel with intra-node migrations
+/// if there is free capacity to carry them out, but across-node migrations have higher priority.
+///
+/// Intra-node migrations are scheduled for each node independently with the aim to equalize
+/// per-shard tablet count on each node.
 ///
 /// If the algorithm is called with active tablet migrations in tablet metadata, those are treated
 /// by load balancer as if they were already completed. This allows the algorithm to incrementally
@@ -224,7 +232,10 @@ class load_balancer {
         // The average shard load on this node.
         load_type avg_load = 0;
 
-        std::vector<shard_id> shards_by_load; // heap which tracks most-loaded shards using shards_by_load_cmp().
+        // heap which tracks most-loaded shards using shards_by_load_cmp().
+        // Valid during intra-node plan-making for nodes which are in the source node set.
+        std::vector<shard_id> shards_by_load;
+
         std::vector<shard_load> shards; // Indexed by shard_id to which a given shard_load corresponds.
 
         std::optional<locator::load_sketch> target_load_sketch;
@@ -637,6 +648,136 @@ public:
 
     bool in_shuffle_mode() const {
         return utils::get_local_injector().enter("tablet_allocator_shuffle");
+    }
+
+    shard_id rand_shard(shard_id shard_count) const {
+        static thread_local std::default_random_engine re{std::random_device{}()};
+        static thread_local std::uniform_int_distribution<shard_id> dist;
+        return dist(re) % shard_count;
+    }
+
+    future<migration_plan> make_node_plan(node_load_map& nodes, host_id host, node_load& node_load) {
+        migration_plan plan;
+        const tablet_metadata& tmeta = _tm->tablets();
+        bool shuffle = in_shuffle_mode();
+
+        if (node_load.shard_count <= 1) {
+            lblogger.debug("Node {} is balanced", host);
+            co_return plan;
+        }
+
+        auto& sketch = co_await node_load.get_load_sketch(_tm);
+
+        // Keeps candidate source shards in a heap which yields highest-loaded shard first.
+        std::vector<shard_id> src_shards;
+        src_shards.reserve(node_load.shard_count);
+        for (shard_id shard = 0; shard < node_load.shard_count; shard++) {
+            src_shards.push_back(shard);
+        }
+        std::make_heap(src_shards.begin(), src_shards.end(), node_load.shards_by_load_cmp());
+
+        size_t max_load = 0; // Tracks max load among shards which ran out of candidates.
+
+        while (true) {
+            co_await coroutine::maybe_yield();
+
+            if (src_shards.empty()) {
+                lblogger.debug("Unable to balance node {}: ran out of candidates, max load: {}, avg load: {}",
+                               host, max_load, node_load.avg_load);
+                break;
+            }
+
+            shard_id src, dst;
+
+            // Post-conditions:
+            // 1) src and dst are chosen.
+            // 2) src_shards.back() == src.
+            if (shuffle) {
+                src = src_shards[rand_shard(src_shards.size())];
+                std::swap(src_shards.back(), src_shards[src]);
+                do {
+                    dst = rand_shard(node_load.shard_count);
+                } while (src == dst); // There are at least two shards here so this converges.
+            } else {
+                std::pop_heap(src_shards.begin(), src_shards.end(), node_load.shards_by_load_cmp());
+                src = src_shards.back();
+                dst = sketch.next_shard(host);
+            }
+
+            auto push_back = seastar::defer([&] {
+                // When shuffling, src_shards is not a heap.
+                if (!shuffle) {
+                    std::push_heap(src_shards.begin(), src_shards.end(), node_load.shards_by_load_cmp());
+                }
+            });
+
+            auto& src_info = node_load.shards[src];
+            auto& dst_info = node_load.shards[dst];
+
+            // Convergence check
+
+            // When in shuffle mode, exit condition is guaranteed by running out of candidates or by load limit.
+            if (!shuffle && (src == dst || src_info.tablet_count <= dst_info.tablet_count + 1)) {
+                lblogger.debug("Node {} is balanced", host);
+                break;
+            }
+
+            if (src_info.candidates.empty()) {
+                lblogger.debug("No more candidates on shard {} of {}", src, host);
+                max_load = std::max(max_load, src_info.tablet_count);
+                src_shards.pop_back();
+                push_back.cancel();
+                continue;
+            }
+
+            auto tablet = *src_info.candidates.begin();
+
+            // Emit migration.
+
+            auto mig = tablet_migration_info {tablet_transition_kind::intranode_migration, tablet,
+                                              tablet_replica{host, src}, tablet_replica{host, dst}};
+            auto& tmap = tmeta.get_tablet_map(tablet.table);
+            auto& src_tinfo = tmap.get_tablet_info(tablet.tablet);
+            auto mig_streaming_info = get_migration_streaming_info(_tm->get_topology(), src_tinfo, mig);
+
+            if (!can_accept_load(nodes, mig_streaming_info)) {
+                _stats.for_dc(node_load.dc()).migrations_skipped++;
+                lblogger.debug("Unable to balance {}: load limit reached", host);
+                break;
+            }
+
+            apply_load(nodes, mig_streaming_info);
+            lblogger.debug("Adding migration: {}", mig);
+            _stats.for_dc(node_load.dc()).migrations_produced++;
+            _stats.for_dc(node_load.dc()).intranode_migrations_produced++;
+            plan.add(std::move(mig));
+
+            for (auto&& r : src_tinfo.replicas) {
+                if (nodes.contains(r.host)) {
+                    nodes[r.host].shards[r.shard].candidates.erase(tablet);
+                }
+            }
+
+            dst_info.tablet_count++;
+            src_info.tablet_count--;
+        }
+
+        co_return plan;
+    }
+
+    future<migration_plan> make_intranode_plan(node_load_map& nodes, const std::unordered_set<host_id>& skip_nodes) {
+        migration_plan plan;
+
+        for (auto&& [host, node_load] : nodes) {
+            if (skip_nodes.contains(host)) {
+                lblogger.debug("Skipped balancing of node {}", host);
+                continue;
+            }
+
+            plan.merge(co_await make_node_plan(nodes, host, node_load));
+        }
+
+        co_return plan;
     }
 
     future<migration_plan> make_internode_plan(const dc_name& dc, node_load_map& nodes,
@@ -1161,6 +1302,10 @@ public:
             plan.merge(co_await make_internode_plan(dc, nodes, nodes_to_drain, target));
         } else {
             _stats.for_dc(dc).stop_balance++;
+        }
+
+        if (_tm->tablets().balancing_enabled()) {
+            plan.merge(co_await make_intranode_plan(nodes, nodes_to_drain));
         }
 
         co_await utils::clear_gently(nodes);

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1120,6 +1120,11 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                     }
                     break;
                 case locator::tablet_transition_stage::write_both_read_new: {
+                    utils::get_local_injector().inject("crash-in-tablet-write-both-read-new", [] {
+                        rtlogger.info("crash-in-tablet-write-both-read-new hit, killing the node");
+                        _exit(1);
+                    });
+
                     auto next_stage = locator::tablet_transition_stage::use_new;
                     if (action_failed(tablet_state.barriers[trinfo.stage])) {
                         auto& tinfo = tmap.get_tablet_info(gid.tablet);

--- a/service/topology_coordinator.cc
+++ b/service/topology_coordinator.cc
@@ -1135,7 +1135,12 @@ class topology_coordinator : public endpoint_lifecycle_subscriber {
                                 excluded_new++;
                             }
                         }
-                        if (excluded_new > excluded_old) {
+                        // Cannot revert if this is intra-node migration.
+                        // We will lose data if the migrating node restarted, in which case the leaving replica
+                        // doesn't contain writes anymore as sstables are attached only on the pending replica.
+                        // Luckily, this we never reach this condition since excluded_new cannot be larger
+                        // than excluded_old for intra-node migration.
+                        if (excluded_new > excluded_old && trinfo.transition != locator::tablet_transition_kind::intranode_migration) {
                             rtlogger.debug("During {} stage of {} {} new nodes and {} old nodes were excluded", trinfo.stage, gid, excluded_new, excluded_old);
                             next_stage = locator::tablet_transition_stage::cleanup_target;
                         }

--- a/sstables/open_info.hh
+++ b/sstables/open_info.hh
@@ -21,16 +21,24 @@
 
 namespace sstables {
 
+enum class sstable_state {
+    normal,
+    staging,
+    quarantine,
+    upload,
+};
+
 struct entry_descriptor {
     generation_type generation;
     sstable_version_types version;
     sstable_format_types format;
     component_type component;
+    std::optional<sstable_state> state;
 
     entry_descriptor(generation_type generation,
                      sstable_version_types version, sstable_format_types format,
-                     component_type component)
-        : generation(generation), version(version), format(format), component(component) {}
+                     component_type component, std::optional<sstable_state> state = {})
+        : generation(generation), version(version), format(format), component(component), state(state) {}
 };
 
 // Parses sstable file path extracting entry_descriptor from it. Returns the descriptor
@@ -68,6 +76,9 @@ struct sstable_open_config {
     // filter, meaning that the SSTable will be opened on every single-partition
     // read.
     bool load_bloom_filter = true;
+    // Mimicks behavior when a SSTable is streamed to a given shard, where SSTable
+    // writer considers the shard that created the SSTable as its owner.
+    bool current_shard_as_sstable_owner = false;
 };
 
 }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -852,6 +852,11 @@ future<std::unordered_map<component_type, file>> sstable::readable_file_for_all_
     co_return std::move(files);
 }
 
+future<entry_descriptor> sstable::clone(generation_type new_generation) const {
+    co_await _storage->snapshot(*this, _storage->prefix(), storage::absolute_path::yes, new_generation);
+    co_return entry_descriptor(new_generation, _version, _format, component_type::TOC, _state);
+}
+
 file_writer::~file_writer() {
     if (_closed) {
         return;
@@ -1444,7 +1449,8 @@ future<> sstable::load(const dht::sharder& sharder, sstable_open_config cfg) noe
     validate_partitioner();
     if (_shards.empty()) {
         set_first_and_last_keys();
-        _shards = compute_shards_for_this_sstable(sharder);
+        _shards = cfg.current_shard_as_sstable_owner ?
+                std::vector<unsigned>{this_shard_id()} : compute_shards_for_this_sstable(sharder);
     }
     co_await open_data(cfg);
 }

--- a/sstables/sstables.cc
+++ b/sstables/sstables.cc
@@ -1597,7 +1597,7 @@ create_sharding_metadata(utils::chunked_vector<dht::partition_range> ranges) {
 
 static
 sharding_metadata
-create_sharding_metadata(schema_ptr schema, const dht::sharder& sharder, const dht::decorated_key& first_key, const dht::decorated_key& last_key, shard_id shard) {
+create_sharding_metadata(schema_ptr schema, const dht::static_sharder& sharder, const dht::decorated_key& first_key, const dht::decorated_key& last_key, shard_id shard) {
     auto prange = dht::partition_range::make(dht::ring_position(first_key), dht::ring_position(last_key));
     auto ranges = dht::split_range_to_single_shard(*schema, sharder, prange, shard).get();
     if (ranges.empty()) {

--- a/sstables/sstables.hh
+++ b/sstables/sstables.hh
@@ -948,6 +948,10 @@ public:
     // Returns a read-only file for all existing components of the sstable
     future<std::unordered_map<component_type, file>> readable_file_for_all_components() const;
 
+    // Clones this sstable with a new generation, under the same location as the original one.
+    // Implementation is underlying storage specific.
+    future<entry_descriptor> clone(generation_type new_generation) const;
+
     // Allow the test cases from sstable_test.cc to test private methods. We use
     // a placeholder to avoid cluttering this class too much. The sstable_test class
     // will then re-export as public every method it needs.

--- a/sstables/sstables_registry.hh
+++ b/sstables/sstables_registry.hh
@@ -11,13 +11,6 @@
 
 namespace sstables {
 
-enum class sstable_state {
-    normal,
-    staging,
-    quarantine,
-    upload,
-};
-
 // sstables_manager needs to store the names of its sstables somewhere, when
 // using object storage. This is system_keyspace, but for modularity we hide
 // it behind this interface.

--- a/sstables/storage.hh
+++ b/sstables/storage.hh
@@ -58,7 +58,7 @@ public:
     using sync_dir = bool_class<struct sync_dir_tag>; // meaningful only to filesystem storage
 
     virtual future<> seal(const sstable& sst) = 0;
-    virtual future<> snapshot(const sstable& sst, sstring dir, absolute_path abs) const = 0;
+    virtual future<> snapshot(const sstable& sst, sstring dir, absolute_path abs, std::optional<generation_type> gen = {}) const = 0;
     virtual future<> change_state(const sstable& sst, sstable_state to, generation_type generation, delayed_commit_changes* delay) = 0;
     // runs in async context
     virtual void open(sstable& sst) = 0;

--- a/streaming/stream_manager.hh
+++ b/streaming/stream_manager.hh
@@ -20,6 +20,8 @@
 #include "gms/inet_address.hh"
 #include "gms/endpoint_state.hh"
 #include "gms/application_state.hh"
+#include "service/topology_guard.hh"
+#include "readers/flat_mutation_reader_v2.hh"
 #include <seastar/core/semaphore.hh>
 #include <seastar/core/metrics_registration.hh>
 
@@ -169,6 +171,8 @@ public:
 
     shared_ptr<stream_session> get_session(streaming::plan_id plan_id, gms::inet_address from, const char* verb, std::optional<table_id> cf_id = {});
 
+    std::function<future<>(flat_mutation_reader_v2)> make_streaming_consumer(
+            uint64_t estimated_partitions, stream_reason, service::frozen_topology_guard);
 public:
     virtual future<> on_join(inet_address endpoint, endpoint_state_ptr ep_state, gms::permit_id) override { return make_ready_future(); }
     virtual future<> on_change(gms::inet_address, const gms::application_state_map& states, gms::permit_id) override  { return make_ready_future(); }

--- a/test/boost/commitlog_test.cc
+++ b/test/boost/commitlog_test.cc
@@ -940,7 +940,7 @@ SEASTAR_TEST_CASE(test_commitlog_replay_invalid_key){
             auto fm = freeze(m);
             commitlog_entry_writer cew(s, fm, db::commitlog::force_sync::yes);
             cl.add_entry(m.column_family_id(), cew, db::no_timeout).get();
-            return sharder.shard_of(m.token());
+            return sharder.shard_for_reads(m.token());
         };
 
         const auto shard = add_entry(partition_key::make_empty());

--- a/test/boost/cql_query_test.cc
+++ b/test/boost/cql_query_test.cc
@@ -5770,7 +5770,7 @@ SEASTAR_TEST_CASE(test_sending_tablet_info_insert) {
 
         auto pk = partition_key::from_singular(*sptr, int32_t(1));
 
-        unsigned local_shard = sptr->table().shard_of(dht::get_token(*sptr, pk.view()));
+        unsigned local_shard = sptr->table().shard_for_reads(dht::get_token(*sptr, pk.view()));
 
         smp::submit_to(local_shard, [&] {
             return seastar::async([&] { 
@@ -5786,7 +5786,7 @@ SEASTAR_TEST_CASE(test_sending_tablet_info_insert) {
 
         auto pk2 = partition_key::from_singular(*sptr, int32_t(2));
 
-        unsigned local_shard2 = sptr->table().shard_of(dht::get_token(*sptr, pk2.view()));
+        unsigned local_shard2 = sptr->table().shard_for_reads(dht::get_token(*sptr, pk2.view()));
         unsigned foreign_shard = (local_shard2 + 1) % smp::count;
 
         smp::submit_to(foreign_shard, [&] { 
@@ -5812,7 +5812,7 @@ SEASTAR_TEST_CASE(test_sending_tablet_info_select) {
 
         auto pk = partition_key::from_singular(*sptr, int32_t(1));
 
-        unsigned local_shard = sptr->table().shard_of(dht::get_token(*sptr, pk.view()));
+        unsigned local_shard = sptr->table().shard_for_reads(dht::get_token(*sptr, pk.view()));
         unsigned foreign_shard = (local_shard + 1) % smp::count;
 
         smp::submit_to(local_shard, [&] { 

--- a/test/boost/database_test.cc
+++ b/test/boost/database_test.cc
@@ -67,7 +67,7 @@ public:
 static future<> apply_mutation(sharded<replica::database>& sharded_db, table_id uuid, const mutation& m, bool do_flush = false,
         db::commitlog::force_sync fs = db::commitlog::force_sync::no, db::timeout_clock::time_point timeout = db::no_timeout) {
     auto& t = sharded_db.local().find_column_family(uuid);
-    auto shard = t.shard_of(m);
+    auto shard = t.shard_for_reads(m.token());
     return sharded_db.invoke_on(shard, [uuid, fm = freeze(m), do_flush, fs, timeout] (replica::database& db) {
         auto& t = db.find_column_family(uuid);
         return db.apply(t.schema(), fm, tracing::trace_state_ptr(), fs, timeout).then([do_flush, &t] {
@@ -113,7 +113,7 @@ SEASTAR_TEST_CASE(test_safety_after_truncate) {
             auto pkey = partition_key::from_single_value(*s, to_bytes(fmt::format("key{}", i)));
             mutation m(s, pkey);
             m.set_clustered_cell(clustering_key_prefix::make_empty(), "v", int32_t(42), {});
-            auto shard = table.shard_of(m);
+            auto shard = table.shard_for_reads(m.token());
             keys_per_shard[shard]++;
             pranges_per_shard[shard].emplace_back(dht::partition_range::make_singular(dht::decorate_key(*s, std::move(pkey))));
             apply_mutation(e.db(), uuid, m).get();
@@ -207,7 +207,7 @@ SEASTAR_TEST_CASE(test_querying_with_limits) {
                 mutation m(s, pkey);
                 m.partition().apply(tombstone(api::timestamp_type(1), gc_clock::now()));
                 apply_mutation(e.db(), uuid, m).get();
-                auto shard = table.shard_of(m);
+                auto shard = table.shard_for_reads(m.token());
                 pranges_per_shard[shard].emplace_back(dht::partition_range::make_singular(dht::decorate_key(*s, std::move(pkey))));
             }
             for (uint32_t i = 3 * smp::count; i <= 8 * smp::count; ++i) {
@@ -215,7 +215,7 @@ SEASTAR_TEST_CASE(test_querying_with_limits) {
                 mutation m(s, pkey);
                 m.set_clustered_cell(clustering_key_prefix::make_empty(), "v", int32_t(42), 1);
                 apply_mutation(e.db(), uuid, m).get();
-                auto shard = table.shard_of(m);
+                auto shard = table.shard_for_reads(m.token());
                 keys_per_shard[shard]++;
                 pranges_per_shard[shard].emplace_back(dht::partition_range::make_singular(dht::decorate_key(*s, std::move(pkey))));
             }

--- a/test/boost/multishard_mutation_query_test.cc
+++ b/test/boost/multishard_mutation_query_test.cc
@@ -227,7 +227,7 @@ static std::vector<mutation> read_all_partitions_one_by_one(distributed<replica:
     results.reserve(pkeys.size());
 
     for (const auto& pkey : pkeys) {
-        const auto res = db.invoke_on(sharder.shard_of(pkey.token()), [gs = global_schema_ptr(s), &pkey, &slice] (replica::database& db) {
+        const auto res = db.invoke_on(sharder.shard_for_reads(pkey.token()), [gs = global_schema_ptr(s), &pkey, &slice] (replica::database& db) {
             return async([s = gs.get(), &pkey, &slice, &db] () mutable {
                 const auto cmd = query::read_command(s->id(), s->version(), slice,
                         query::max_result_size(query::result_memory_limiter::unlimited_result_size), query::tombstone_limit::max);

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -2003,12 +2003,12 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_only_reads_from_needed
         dht::token end_token(dht::token_kind::key, 0);
         const auto additional_shards = tests::random::get_int<unsigned>(0, smp::count - 1);
 
-        auto shard = sharder.shard_of(start_token);
+        auto shard = sharder.shard_for_reads(start_token);
         expected_shards_touched[shard] = true;
 
         for (auto i = 0u; i < additional_shards; ++i) {
             shard = (shard + 1) % smp::count;
-            end_token = sharder.token_for_next_shard(end_token, shard);
+            end_token = sharder.token_for_next_shard_for_reads(end_token, shard);
             expected_shards_touched[shard] = true;
         }
         const auto inclusive_end = !additional_shards || tests::random::get_bool();

--- a/test/boost/mutation_reader_test.cc
+++ b/test/boost/mutation_reader_test.cc
@@ -1941,7 +1941,7 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_combining_reader_custom_shard_number) {
     do_with_cql_env_thread([&] (cql_test_env& env) -> future<> {
         std::vector<std::atomic<bool>> shards_touched(smp::count);
         simple_schema s;
-        auto sharder = std::make_unique<dht::sharder>(no_shards, 0);
+        auto sharder = std::make_unique<dht::static_sharder>(no_shards, 0);
         auto factory = [&shards_touched] (
                 schema_ptr s,
                 reader_permit permit,
@@ -2304,7 +2304,7 @@ SEASTAR_THREAD_TEST_CASE(test_multishard_streaming_reader) {
         auto partition_range = dht::to_partition_range(token_range);
 
         auto& local_partitioner = schema->get_sharder();
-        auto remote_partitioner = dht::sharder(local_partitioner.shard_count() - 1, local_partitioner.sharding_ignore_msb());
+        auto remote_partitioner = dht::static_sharder(local_partitioner.shard_count() - 1, local_partitioner.sharding_ignore_msb());
 
         auto tested_reader = make_multishard_streaming_reader(env.db(), schema, make_reader_permit(env),
                 [sharder = dht::selective_token_range_sharder(remote_partitioner, token_range, 0)] () mutable -> std::optional<dht::partition_range> {

--- a/test/boost/mutation_writer_test.cc
+++ b/test/boost/mutation_writer_test.cc
@@ -61,7 +61,7 @@ SEASTAR_TEST_CASE(test_multishard_writer) {
                 schema_ptr s = gen.schema();
 
                 for (auto& m : muts) {
-                    auto shard = s->get_sharder().shard_of(m.token());
+                    auto shard = s->get_sharder().shard_for_reads(m.token());
                     shards_before[shard]++;
                 }
                 auto source_reader = partition_nr > 0 ? make_flat_mutation_reader_from_mutations_v2(gen.schema(), make_reader_permit(e), muts) : make_empty_flat_reader_v2(s, make_reader_permit(e));
@@ -80,7 +80,7 @@ SEASTAR_TEST_CASE(test_multishard_writer) {
                             return reader().then([&sharder, &shards_after] (mutation_fragment_v2_opt mf_opt) mutable {
                                 if (mf_opt) {
                                     if (mf_opt->is_partition_start()) {
-                                        auto shard = sharder.shard_of(mf_opt->as_partition_start().key().token());
+                                        auto shard = sharder.shard_for_reads(mf_opt->as_partition_start().key().token());
                                         BOOST_REQUIRE_EQUAL(shard, this_shard_id());
                                         shards_after[shard]++;
                                     }
@@ -151,7 +151,7 @@ SEASTAR_TEST_CASE(test_multishard_writer_producer_aborts) {
                             return reader().then([&sharder] (mutation_fragment_v2_opt mf_opt) mutable {
                                 if (mf_opt) {
                                     if (mf_opt->is_partition_start()) {
-                                        auto shard = sharder.shard_of(mf_opt->as_partition_start().key().token());
+                                        auto shard = sharder.shard_for_reads(mf_opt->as_partition_start().key().token());
                                         BOOST_REQUIRE_EQUAL(shard, this_shard_id());
                                     }
                                     return make_ready_future<stop_iteration>(stop_iteration::no);

--- a/test/boost/partitioner_test.cc
+++ b/test/boost/partitioner_test.cc
@@ -392,7 +392,7 @@ public:
 
 static
 void
-test_something_with_some_interesting_ranges_and_sharder(std::function<void (const schema&, const dht::sharder&, const dht::partition_range&)> func_to_test) {
+test_something_with_some_interesting_ranges_and_sharder(std::function<void (const schema&, const dht::static_sharder&, const dht::partition_range&)> func_to_test) {
     auto s = schema_builder("ks", "cf")
         .with_column("c1", int32_type, column_kind::partition_key)
         .with_column("c2", int32_type, column_kind::partition_key)
@@ -447,7 +447,7 @@ test_something_with_some_interesting_ranges_and_sharder(std::function<void (cons
 
 static
 void
-do_test_split_range_to_single_shard(const schema& s, const dht::sharder& sharder_, const dht::partition_range& pr) {
+do_test_split_range_to_single_shard(const schema& s, const dht::static_sharder& sharder_, const dht::partition_range& pr) {
     for (auto shard : boost::irange(0u, sharder_.shard_count())) {
         auto ranges = dht::split_range_to_single_shard(s, sharder_, pr, shard).get();
         auto sharder = dht::ring_position_range_sharder(sharder_, pr);

--- a/test/boost/partitioner_test.cc
+++ b/test/boost/partitioner_test.cc
@@ -245,19 +245,19 @@ SEASTAR_THREAD_TEST_CASE(test_murmur3_sharding) {
         return boost::copy_range<std::vector<dht::token>>(
                 v | boost::adaptors::transformed(token_from_long));
     };
-    dht::sharder mm3p7s(7);
+    dht::static_sharder mm3p7s(7);
     auto mm3p7s_shard_limits = make_token_vector({
         -9223372036854775807, -6588122883467697006+1, -3952873730080618204+1,
         -1317624576693539402+1, 1317624576693539401+1, 3952873730080618203+1,
         6588122883467697005+1,
     });
     test_sharding(mm3p7s, 7, mm3p7s_shard_limits);
-    dht::sharder mm3p2s(2);
+    dht::static_sharder mm3p2s(2);
     auto mm3p2s_shard_limits = make_token_vector({
         -9223372036854775807, 0,
     });
     test_sharding(mm3p2s, 2, mm3p2s_shard_limits);
-    dht::sharder mm3p1s(1);
+    dht::static_sharder mm3p1s(1);
     auto mm3p1s_shard_limits = make_token_vector({
         -9223372036854775807,
     });
@@ -269,7 +269,7 @@ SEASTAR_THREAD_TEST_CASE(test_murmur3_sharding_with_ignorebits) {
         return boost::copy_range<std::vector<dht::token>>(
                 v | boost::adaptors::transformed(token_from_long));
     };
-    dht::sharder mm3p7s2i(7, 2);
+    dht::static_sharder mm3p7s2i(7, 2);
     auto mm3p7s2i_shard_limits = make_token_vector({
         -9223372036854775807,
         -8564559748508006107, -7905747460161236406, -7246935171814466706, -6588122883467697005,
@@ -281,7 +281,7 @@ SEASTAR_THREAD_TEST_CASE(test_murmur3_sharding_with_ignorebits) {
         7905747460161236407, 8564559748508006108,
     });
     test_sharding(mm3p7s2i, 7, mm3p7s2i_shard_limits, 2);
-    dht::sharder mm3p2s4i(2, 4);
+    dht::static_sharder mm3p2s4i(2, 4);
     auto mm3p2s_shard_limits = make_token_vector({
         -9223372036854775807,
         -8646911284551352320, -8070450532247928832, -7493989779944505344, -6917529027641081856,
@@ -310,7 +310,7 @@ normalize(dht::partition_range pr) {
     return dht::partition_range(start, end);
 };
 
-class map_sharder : public dht::sharder {
+class map_sharder : public dht::static_sharder {
     // Defines mapping of tokens to shards.
     //
     // For example, {t1:s1, t2:s2, t3:s3} defines the following mapping on token ranges:
@@ -322,7 +322,7 @@ class map_sharder : public dht::sharder {
     //
     std::map<dht::token, unsigned> _shards;
 public:
-    map_sharder(unsigned num_shards) : dht::sharder(num_shards) {}
+    map_sharder(unsigned num_shards) : dht::static_sharder(num_shards) {}
 
     const std::map<dht::token, unsigned>& get_map() const {
         return _shards;
@@ -399,10 +399,10 @@ test_something_with_some_interesting_ranges_and_sharder(std::function<void (cons
         .with_column("v", int32_type)
         .build();
     auto some_sharders = {
-            dht::sharder(1, 0),
-            dht::sharder(7, 4),
-            dht::sharder(4, 0),
-            dht::sharder(32, 8),  // More, and we OOM since memory isn't configured
+            dht::static_sharder(1, 0),
+            dht::static_sharder(7, 4),
+            dht::static_sharder(4, 0),
+            dht::static_sharder(32, 8),  // More, and we OOM since memory isn't configured
     };
     auto t1 = token_from_long(int64_t(-0x7fff'ffff'ffff'fffe));
     auto t2 = token_from_long(int64_t(-1));
@@ -483,10 +483,10 @@ test_something_with_some_interesting_ranges_and_sharder_with_token_range(std::fu
         .with_column("v", int32_type)
         .build();
     auto some_sharder = {
-            dht::sharder(1, 0),
-            dht::sharder(7, 4),
-            dht::sharder(4, 0),
-            dht::sharder(32, 8),  // More, and we OOM since memory isn't configured
+            dht::static_sharder(1, 0),
+            dht::static_sharder(7, 4),
+            dht::static_sharder(4, 0),
+            dht::static_sharder(32, 8),  // More, and we OOM since memory isn't configured
     };
     auto t1 = token_from_long(int64_t(-0x7fff'ffff'ffff'fffe));
     auto t2 = token_from_long(int64_t(-1));
@@ -561,7 +561,7 @@ SEASTAR_THREAD_TEST_CASE(test_selective_token_range_sharder) {
 SEASTAR_THREAD_TEST_CASE(test_find_first_token_for_shard) {
     const unsigned cpu_count = 3;
     const unsigned ignore_msb_bits = 10;
-    dht::sharder sharder(cpu_count, ignore_msb_bits);
+    dht::static_sharder sharder(cpu_count, ignore_msb_bits);
     auto first_boundary = sharder.token_for_next_shard(dht::minimum_token(), 1);
     auto second_boundary = sharder.token_for_next_shard(dht::minimum_token(), 2);
     auto third_boundary = sharder.token_for_next_shard(dht::minimum_token(), 0);

--- a/test/boost/partitioner_test.cc
+++ b/test/boost/partitioner_test.cc
@@ -228,14 +228,14 @@ void test_sharding(const dht::sharder& sharder, unsigned shards, std::vector<dht
         .build();
     for (unsigned i = 0; i < (shards << ignorebits); ++i) {
         auto lim = shard_limits[i];
-        BOOST_REQUIRE_EQUAL(sharder.shard_of(lim), i % shards);
+        BOOST_REQUIRE_EQUAL(sharder.shard_for_reads(lim), i % shards);
         if (i != 0) {
-            BOOST_REQUIRE_EQUAL(sharder.shard_of(prev_token(lim)), (i - 1) % shards);
-            BOOST_REQUIRE_EQUAL(lim, sharder.token_for_next_shard(prev_token(lim), i % shards));
+            BOOST_REQUIRE_EQUAL(sharder.shard_for_reads(prev_token(lim)), (i - 1) % shards);
+            BOOST_REQUIRE_EQUAL(lim, sharder.token_for_next_shard_for_reads(prev_token(lim), i % shards));
         }
         if (i != (shards << ignorebits) - 1) {
             auto next_shard = (i + 1) % shards;
-            BOOST_REQUIRE_EQUAL(sharder.shard_of(sharder.token_for_next_shard(lim, next_shard)), next_shard);
+            BOOST_REQUIRE_EQUAL(sharder.shard_for_reads(sharder.token_for_next_shard_for_reads(lim, next_shard)), next_shard);
         }
     }
 }
@@ -524,7 +524,7 @@ do_test_selective_token_range_sharder(const dht::sharder& input_sharder, const s
         auto range_shard = sharder.next();
         while (range_shard) {
             if (range_shard->start() && range_shard->start()->is_inclusive()) {
-                auto start_shard = input_sharder.shard_of(range_shard->start()->value());
+                auto start_shard = input_sharder.shard_for_reads(range_shard->start()->value());
                 if (debug) {
                     fmt::print(" start_shard {} shard {} range {}\n",
                                start_shard, shard, range_shard);
@@ -532,7 +532,7 @@ do_test_selective_token_range_sharder(const dht::sharder& input_sharder, const s
                 BOOST_REQUIRE(start_shard == shard);
             }
             if (range_shard->end() && range_shard->end()->is_inclusive()) {
-                auto end_shard = input_sharder.shard_of(range_shard->end()->value());
+                auto end_shard = input_sharder.shard_for_reads(range_shard->end()->value());
                 if (debug) {
                     fmt::print(" end_shard {} shard range {}\n",
                                end_shard, shard, range_shard);
@@ -542,7 +542,7 @@ do_test_selective_token_range_sharder(const dht::sharder& input_sharder, const s
             auto midpoint = dht::token::midpoint(
                     range_shard->start() ? range_shard->start()->value() : dht::minimum_token(),
                     range_shard->end() ? range_shard->end()->value() : dht::minimum_token());
-            auto mid_shard = input_sharder.shard_of(midpoint);
+            auto mid_shard = input_sharder.shard_for_reads(midpoint);
             if (debug) {
                 fmt::print(" mid {} shard {} range {}\n",
                            mid_shard, shard, range_shard);
@@ -562,9 +562,9 @@ SEASTAR_THREAD_TEST_CASE(test_find_first_token_for_shard) {
     const unsigned cpu_count = 3;
     const unsigned ignore_msb_bits = 10;
     dht::static_sharder sharder(cpu_count, ignore_msb_bits);
-    auto first_boundary = sharder.token_for_next_shard(dht::minimum_token(), 1);
-    auto second_boundary = sharder.token_for_next_shard(dht::minimum_token(), 2);
-    auto third_boundary = sharder.token_for_next_shard(dht::minimum_token(), 0);
+    auto first_boundary = sharder.token_for_next_shard_for_reads(dht::minimum_token(), 1);
+    auto second_boundary = sharder.token_for_next_shard_for_reads(dht::minimum_token(), 2);
+    auto third_boundary = sharder.token_for_next_shard_for_reads(dht::minimum_token(), 0);
     auto next_token = [] (dht::token t) {
         assert(dht::token::to_int64(t) < std::numeric_limits<int64_t>::max());
         return dht::token::from_int64(dht::token::to_int64(t) + 1);
@@ -618,7 +618,7 @@ SEASTAR_THREAD_TEST_CASE(test_find_first_token_for_shard) {
             dht::find_first_token_for_shard(sharder, prev_token(first_boundary), prev_token(third_boundary), 0));
 
     auto last_token = dht::token::from_int64(std::numeric_limits<int64_t>::max());
-    auto last_shard = sharder.shard_of(last_token);
+    auto last_shard = sharder.shard_for_reads(last_token);
 
     BOOST_REQUIRE_EQUAL(last_token,
             dht::find_first_token_for_shard(sharder, prev_token(last_token), dht::maximum_token(), last_shard));

--- a/test/boost/per_partition_rate_limit_test.cc
+++ b/test/boost/per_partition_rate_limit_test.cc
@@ -24,7 +24,7 @@ SEASTAR_TEST_CASE(test_internal_operation_filtering) {
 
         auto pk = partition_key::from_singular(*sptr, int32_t(0));
 
-        unsigned local_shard = sptr->table().shard_of(dht::get_token(*sptr, pk.view()));
+        unsigned local_shard = sptr->table().shard_for_reads(dht::get_token(*sptr, pk.view()));
         unsigned foreign_shard = (local_shard + 1) % smp::count;
         
         auto run_writes = [&qp, &db, pk] (db::allow_per_partition_rate_limit allow_limit) -> future<> {

--- a/test/boost/repair_test.cc
+++ b/test/boost/repair_test.cc
@@ -167,7 +167,7 @@ SEASTAR_TEST_CASE(test_reader_with_different_strategies) {
             co_await storage_proxy.mutate_locally(std::move(mutations), tracing::trace_state_ptr());
         }
 
-        auto do_check = [&](const dht::sharder& remote_sharder,
+        auto do_check = [&](const dht::static_sharder& remote_sharder,
             repair_reader::read_strategy strategy1, repair_reader::read_strategy strategy2) -> future<>
         {
             const auto& s = *cf.schema();
@@ -225,7 +225,7 @@ SEASTAR_TEST_CASE(test_reader_with_different_strategies) {
             }
         };
 
-        co_await do_check(dht::sharder(local_sharder.shard_count() + 1, local_sharder.sharding_ignore_msb()),
+        co_await do_check(dht::static_sharder(local_sharder.shard_count() + 1, local_sharder.sharding_ignore_msb()),
             repair_reader::read_strategy::multishard_split,
             repair_reader::read_strategy::multishard_filter);
         co_await do_check(local_sharder,

--- a/test/boost/secondary_index_test.cc
+++ b/test/boost/secondary_index_test.cc
@@ -1895,7 +1895,7 @@ SEASTAR_TEST_CASE(test_deleting_ghost_rows) {
                 mutation m(schema, partition_key::from_singular(*schema, pk));
                 auto& row = m.partition().clustered_row(*schema, clustering_key::from_exploded(*schema, {int32_type->decompose(8), int32_type->decompose(7)}));
                 row.apply(row_marker{api::new_timestamp()});
-                unsigned shard = t.shard_of(m);
+                unsigned shard = t.shard_for_reads(m.token());
                 if (shard == this_shard_id()) {
                     t.apply(m);
                 }

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -1672,6 +1672,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_two_empty_nodes) {
         for (auto h : {host1, host2, host3, host4}) {
             testlog.debug("Checking host {}", h);
             BOOST_REQUIRE_EQUAL(load.get_avg_shard_load(h), 4);
+            BOOST_REQUIRE_LE(load.get_shard_imbalance(h), 1);
         }
     }
   }).get();
@@ -1861,6 +1862,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancing_with_random_load) {
                 auto l = load.get_avg_shard_load(h);
                 testlog.info("Load on host {}: {}", h, l);
                 min_max_load.update(l);
+                BOOST_REQUIRE_LE(load.get_shard_imbalance(h), 1);
             }
 
             testlog.debug("tablet metadata: {}", stm.get()->tablets());

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -744,7 +744,9 @@ SEASTAR_TEST_CASE(test_sharder) {
         }
 
         auto& tm = tokm.tablets().get_tablet_map(table1);
-        tablet_sharder sharder(tokm, table1);
+        tablet_sharder sharder(tokm, table1); // for h1
+        tablet_sharder sharder_h3(tokm, table1, h3);
+
         BOOST_REQUIRE_EQUAL(sharder.shard_for_reads(tm.get_last_token(tablet_ids[0])), 3);
         BOOST_REQUIRE_EQUAL(sharder.shard_for_reads(tm.get_last_token(tablet_ids[1])), 0); // missing
         BOOST_REQUIRE_EQUAL(sharder.shard_for_reads(tm.get_last_token(tablet_ids[2])), 1);
@@ -765,6 +767,16 @@ SEASTAR_TEST_CASE(test_sharder) {
         BOOST_REQUIRE_EQUAL(sharder.shard_for_writes(tm.get_last_token(tablet_ids[5])), dht::shard_replica_set{5});
         BOOST_REQUIRE_EQUAL(sharder.shard_for_writes(tm.get_last_token(tablet_ids[6])), dht::shard_replica_set{5});
         BOOST_REQUIRE_EQUAL(sharder.shard_for_writes(tm.get_last_token(tablet_ids[7])), dht::shard_replica_set{5});
+
+        // On pending host
+        BOOST_REQUIRE_EQUAL(sharder_h3.shard_for_reads(tm.get_last_token(tablet_ids[4])), 7);
+        BOOST_REQUIRE_EQUAL(sharder_h3.shard_for_reads(tm.get_last_token(tablet_ids[5])), 7);
+        BOOST_REQUIRE_EQUAL(sharder_h3.shard_for_reads(tm.get_last_token(tablet_ids[6])), 7);
+        BOOST_REQUIRE_EQUAL(sharder_h3.shard_for_reads(tm.get_last_token(tablet_ids[7])), 7);
+        BOOST_REQUIRE_EQUAL(sharder_h3.shard_for_writes(tm.get_last_token(tablet_ids[4])), dht::shard_replica_set{7});
+        BOOST_REQUIRE_EQUAL(sharder_h3.shard_for_writes(tm.get_last_token(tablet_ids[5])), dht::shard_replica_set{7});
+        BOOST_REQUIRE_EQUAL(sharder_h3.shard_for_writes(tm.get_last_token(tablet_ids[6])), dht::shard_replica_set{7});
+        BOOST_REQUIRE_EQUAL(sharder_h3.shard_for_writes(tm.get_last_token(tablet_ids[7])), dht::shard_replica_set{7});
 
         BOOST_REQUIRE_EQUAL(sharder.token_for_next_shard_for_reads(tm.get_last_token(tablet_ids[1]), 0), tm.get_first_token(tablet_ids[3]));
         BOOST_REQUIRE_EQUAL(sharder.token_for_next_shard_for_reads(tm.get_last_token(tablet_ids[1]), 1), tm.get_first_token(tablet_ids[2]));

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -1688,7 +1688,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancer_disabling) {
 
         auto table1 = table_id(next_uuid());
 
-        unsigned shard_count = 1;
+        unsigned shard_count = 2;
 
         semaphore sem(1);
         shared_token_metadata stm([&sem] () noexcept { return get_units(sem, 1); }, locator::token_metadata::config{
@@ -1699,6 +1699,7 @@ SEASTAR_THREAD_TEST_CASE(test_load_balancer_disabling) {
         });
 
         // host1 is loaded and host2 is empty, resulting in an imbalance.
+        // host1's shard 0 is loaded and shard 1 is empty, resulting in intra-node imbalance.
         stm.mutate_token_metadata([&] (auto& tm) {
             tm.update_host_id(host1, ip1);
             tm.update_host_id(host2, ip2);

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -401,7 +401,7 @@ SEASTAR_TEST_CASE(test_get_shard) {
 
         auto get_shard = [&] (tablet_id tid, host_id host) {
             tablet_sharder sharder(*stm.get(), table1, host);
-            return sharder.shard_of(tmap.get_last_token(tid));
+            return sharder.shard_for_reads(tmap.get_last_token(tid));
         };
 
         BOOST_REQUIRE_EQUAL(get_shard(tid1, h1), std::make_optional(shard_id(2)));
@@ -766,37 +766,37 @@ SEASTAR_TEST_CASE(test_sharder) {
         BOOST_REQUIRE_EQUAL(sharder.shard_for_writes(tm.get_last_token(tablet_ids[6])), dht::shard_replica_set{5});
         BOOST_REQUIRE_EQUAL(sharder.shard_for_writes(tm.get_last_token(tablet_ids[7])), dht::shard_replica_set{5});
 
-        BOOST_REQUIRE_EQUAL(sharder.token_for_next_shard(tm.get_last_token(tablet_ids[1]), 0), tm.get_first_token(tablet_ids[3]));
-        BOOST_REQUIRE_EQUAL(sharder.token_for_next_shard(tm.get_last_token(tablet_ids[1]), 1), tm.get_first_token(tablet_ids[2]));
-        BOOST_REQUIRE_EQUAL(sharder.token_for_next_shard(tm.get_last_token(tablet_ids[1]), 3), dht::maximum_token());
+        BOOST_REQUIRE_EQUAL(sharder.token_for_next_shard_for_reads(tm.get_last_token(tablet_ids[1]), 0), tm.get_first_token(tablet_ids[3]));
+        BOOST_REQUIRE_EQUAL(sharder.token_for_next_shard_for_reads(tm.get_last_token(tablet_ids[1]), 1), tm.get_first_token(tablet_ids[2]));
+        BOOST_REQUIRE_EQUAL(sharder.token_for_next_shard_for_reads(tm.get_last_token(tablet_ids[1]), 3), dht::maximum_token());
 
-        BOOST_REQUIRE_EQUAL(sharder.token_for_next_shard(tm.get_first_token(tablet_ids[1]), 0), tm.get_first_token(tablet_ids[3]));
-        BOOST_REQUIRE_EQUAL(sharder.token_for_next_shard(tm.get_first_token(tablet_ids[1]), 1), tm.get_first_token(tablet_ids[2]));
-        BOOST_REQUIRE_EQUAL(sharder.token_for_next_shard(tm.get_first_token(tablet_ids[1]), 3), dht::maximum_token());
+        BOOST_REQUIRE_EQUAL(sharder.token_for_next_shard_for_reads(tm.get_first_token(tablet_ids[1]), 0), tm.get_first_token(tablet_ids[3]));
+        BOOST_REQUIRE_EQUAL(sharder.token_for_next_shard_for_reads(tm.get_first_token(tablet_ids[1]), 1), tm.get_first_token(tablet_ids[2]));
+        BOOST_REQUIRE_EQUAL(sharder.token_for_next_shard_for_reads(tm.get_first_token(tablet_ids[1]), 3), dht::maximum_token());
 
         {
-            auto shard_opt = sharder.next_shard(tm.get_last_token(tablet_ids[0]));
+            auto shard_opt = sharder.next_shard_for_reads(tm.get_last_token(tablet_ids[0]));
             BOOST_REQUIRE(shard_opt);
             BOOST_REQUIRE_EQUAL(shard_opt->shard, 0);
             BOOST_REQUIRE_EQUAL(shard_opt->token, tm.get_first_token(tablet_ids[1]));
         }
 
         {
-            auto shard_opt = sharder.next_shard(tm.get_last_token(tablet_ids[1]));
+            auto shard_opt = sharder.next_shard_for_reads(tm.get_last_token(tablet_ids[1]));
             BOOST_REQUIRE(shard_opt);
             BOOST_REQUIRE_EQUAL(shard_opt->shard, 1);
             BOOST_REQUIRE_EQUAL(shard_opt->token, tm.get_first_token(tablet_ids[2]));
         }
 
         {
-            auto shard_opt = sharder.next_shard(tm.get_last_token(tablet_ids[2]));
+            auto shard_opt = sharder.next_shard_for_reads(tm.get_last_token(tablet_ids[2]));
             BOOST_REQUIRE(shard_opt);
             BOOST_REQUIRE_EQUAL(shard_opt->shard, 0);
             BOOST_REQUIRE_EQUAL(shard_opt->token, tm.get_first_token(tablet_ids[3]));
         }
 
         {
-            auto shard_opt = sharder.next_shard(tm.get_last_token(tablet_ids[tablet_ids.size() - 1]));
+            auto shard_opt = sharder.next_shard_for_reads(tm.get_last_token(tablet_ids[tablet_ids.size() - 1]));
             BOOST_REQUIRE(!shard_opt);
         }
     }, tablet_cql_test_config());

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -745,10 +745,10 @@ SEASTAR_TEST_CASE(test_sharder) {
 
         auto& tm = tokm.tablets().get_tablet_map(table1);
         tablet_sharder sharder(tokm, table1);
-        BOOST_REQUIRE_EQUAL(sharder.shard_of(tm.get_last_token(tablet_ids[0])), 3);
-        BOOST_REQUIRE_EQUAL(sharder.shard_of(tm.get_last_token(tablet_ids[1])), 0); // missing
-        BOOST_REQUIRE_EQUAL(sharder.shard_of(tm.get_last_token(tablet_ids[2])), 1);
-        BOOST_REQUIRE_EQUAL(sharder.shard_of(tm.get_last_token(tablet_ids[3])), 0); // missing
+        BOOST_REQUIRE_EQUAL(sharder.shard_for_reads(tm.get_last_token(tablet_ids[0])), 3);
+        BOOST_REQUIRE_EQUAL(sharder.shard_for_reads(tm.get_last_token(tablet_ids[1])), 0); // missing
+        BOOST_REQUIRE_EQUAL(sharder.shard_for_reads(tm.get_last_token(tablet_ids[2])), 1);
+        BOOST_REQUIRE_EQUAL(sharder.shard_for_reads(tm.get_last_token(tablet_ids[3])), 0); // missing
 
         BOOST_REQUIRE_EQUAL(sharder.shard_for_writes(tm.get_last_token(tablet_ids[0])), dht::shard_replica_set{3});
         BOOST_REQUIRE_EQUAL(sharder.shard_for_writes(tm.get_last_token(tablet_ids[1])), dht::shard_replica_set{});
@@ -757,10 +757,10 @@ SEASTAR_TEST_CASE(test_sharder) {
 
         // Shard for read should be stable across stages of migration. The coordinator may route
         // requests to the leaving replica even if the stage on the replica side is use_new.
-        BOOST_REQUIRE_EQUAL(sharder.shard_of(tm.get_last_token(tablet_ids[4])), 5);
-        BOOST_REQUIRE_EQUAL(sharder.shard_of(tm.get_last_token(tablet_ids[5])), 5);
-        BOOST_REQUIRE_EQUAL(sharder.shard_of(tm.get_last_token(tablet_ids[6])), 5);
-        BOOST_REQUIRE_EQUAL(sharder.shard_of(tm.get_last_token(tablet_ids[7])), 5);
+        BOOST_REQUIRE_EQUAL(sharder.shard_for_reads(tm.get_last_token(tablet_ids[4])), 5);
+        BOOST_REQUIRE_EQUAL(sharder.shard_for_reads(tm.get_last_token(tablet_ids[5])), 5);
+        BOOST_REQUIRE_EQUAL(sharder.shard_for_reads(tm.get_last_token(tablet_ids[6])), 5);
+        BOOST_REQUIRE_EQUAL(sharder.shard_for_reads(tm.get_last_token(tablet_ids[7])), 5);
         BOOST_REQUIRE_EQUAL(sharder.shard_for_writes(tm.get_last_token(tablet_ids[4])), dht::shard_replica_set{5});
         BOOST_REQUIRE_EQUAL(sharder.shard_for_writes(tm.get_last_token(tablet_ids[5])), dht::shard_replica_set{5});
         BOOST_REQUIRE_EQUAL(sharder.shard_for_writes(tm.get_last_token(tablet_ids[6])), dht::shard_replica_set{5});

--- a/test/boost/tablets_test.cc
+++ b/test/boost/tablets_test.cc
@@ -795,7 +795,7 @@ void rebalance_tablets(tablet_allocator& talloc, shared_token_metadata& stm, loc
     auto max_iterations = 1 + get_tablet_count(stm.get()->tablets()) * 10;
 
     for (size_t i = 0; i < max_iterations; ++i) {
-        auto plan = talloc.balance_tablets(stm.get(), load_stats, std::move(skiplist)).get();
+        auto plan = talloc.balance_tablets(stm.get(), load_stats, skiplist).get();
         if (plan.empty()) {
             return;
         }

--- a/test/cql-pytest/test_tablets.py
+++ b/test/cql-pytest/test_tablets.py
@@ -55,6 +55,14 @@ def test_alter_cannot_change_vnodes_to_tablets(cql, skip_without_tablets):
             cql.execute(f"ALTER KEYSPACE {keyspace} WITH replication = {{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}} AND tablets = {{'initial': 1}};")
 
 
+# Counters are not supported with tablets
+def test_counters_are_not_supported(cql, skip_without_tablets):
+    ksdef = "WITH REPLICATION = { 'class' : 'NetworkTopologyStrategy', 'replication_factor' : '1' } AND TABLETS = { 'enabled' : true }"
+    with new_test_keyspace(cql, ksdef) as keyspace:
+        with pytest.raises(InvalidRequest, match="Counters are not supported"):
+            cql.execute(f"CREATE TABLE {keyspace}.test (p int PRIMARY KEY, c counter)")
+
+
 # Converting vnodes-based keyspace to tablets-based in not implemented yet
 def test_alter_doesnt_enable_tablets(cql, skip_without_tablets):
     ksdef = "WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1};"

--- a/test/lib/cql_assertions.cc
+++ b/test/lib/cql_assertions.cc
@@ -250,7 +250,7 @@ future<> require_column_has_value(cql_test_env& e, const sstring& table_name,
     auto ckey = clustering_key::from_deeply_exploded(*schema, ck);
     auto exp = expected.type()->decompose(expected);
     auto dk = dht::decorate_key(*schema, pkey);
-    auto shard = cf.get_effective_replication_map()->shard_of(*schema, dk._token);
+    auto shard = cf.get_effective_replication_map()->shard_for_reads(*schema, dk._token);
     return e.db().invoke_on(shard, [&e, dk = std::move(dk),
                                   ckey = std::move(ckey),
                                   column_name = std::move(column_name),

--- a/test/lib/dummy_sharder.hh
+++ b/test/lib/dummy_sharder.hh
@@ -13,7 +13,7 @@
 #include "dht/token-sharding.hh"
 
 // Shards tokens such that tokens are owned by shards in a round-robin manner.
-class dummy_sharder : public dht::sharder {
+class dummy_sharder : public dht::static_sharder {
     std::vector<dht::token> _tokens;
 
 public:
@@ -23,8 +23,8 @@ public:
     // ordered associative container (std::map) that has dht::token as keys.
     // Values will be ignored.
     template <typename T>
-    dummy_sharder(const dht::sharder& sharding, const std::map<dht::token, T>& something_by_token)
-        : sharder(sharding)
+    dummy_sharder(const dht::static_sharder& sharding, const std::map<dht::token, T>& something_by_token)
+        : dht::static_sharder(sharding)
         , _tokens(boost::copy_range<std::vector<dht::token>>(something_by_token | boost::adaptors::map_keys)) {
     }
 

--- a/test/pylib/rest_client.py
+++ b/test/pylib/rest_client.py
@@ -241,6 +241,9 @@ class ScyllaRESTAPIClient():
             "token": str(token)
         })
 
+    async def quiesce_topology(self, node_ip: str) -> None:
+        await self.client.post(f"/storage_service/quiesce_topology", host=node_ip)
+
     async def add_tablet_replica(self, node_ip: str, ks: str, table: str, dst_host: HostID, dst_shard: int, token: int) -> None:
         await self.client.post(f"/storage_service/tablets/add_replica", host=node_ip, params={
             "ks": ks,

--- a/test/topology_experimental_raft/test_tablets.py
+++ b/test/topology_experimental_raft/test_tablets.py
@@ -193,10 +193,12 @@ async def test_topology_changes(manager: ManagerClient):
 
     keys = range(256)
     await asyncio.gather(*[cql.run_async(f"INSERT INTO test.test (pk, c) VALUES ({k}, {k});") for k in keys])
+    expected_rows = await cql.run_async("SELECT * FROM test.test;")
 
     async def check():
         logger.info("Checking table")
         rows = await cql.run_async("SELECT * FROM test.test;")
+        assert rows == expected_rows
         assert len(rows) == len(keys)
         for r in rows:
             assert r.c == r.pk

--- a/test/topology_experimental_raft/test_tablets_intranode.py
+++ b/test/topology_experimental_raft/test_tablets_intranode.py
@@ -1,0 +1,122 @@
+#
+# Copyright (C) 2024-present ScyllaDB
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+from cassandra.query import SimpleStatement, ConsistencyLevel
+from cassandra.cluster import Session, ConsistencyLevel
+
+from test.pylib.internal_types import ServerInfo
+from test.pylib.manager_client import ManagerClient
+from test.pylib.rest_client import inject_error_one_shot, HTTPError
+from test.pylib.rest_client import inject_error
+from test.pylib.util import wait_for_cql_and_get_hosts, read_barrier
+from test.pylib.tablets import get_tablet_replica, get_all_tablet_replicas
+from test.topology.conftest import skip_mode
+from test.topology.util import reconnect_driver
+
+import pytest
+import asyncio
+import logging
+import time
+import random
+import os
+import glob
+from typing import NamedTuple
+import threading
+
+
+logger = logging.getLogger(__name__)
+
+
+class KeyGenerator:
+    def __init__(self):
+        self.pk = None
+        self.pk_lock = threading.Lock()
+
+    def next_pk(self):
+        with self.pk_lock:
+            if self.pk is not None:
+                self.pk += 1
+            else:
+                self.pk = 0
+            return self.pk
+
+    def last_pk(self):
+        with self.pk_lock:
+            return self.pk
+
+async def start_writes(cql: Session, keyspace: str, table: str, concurrency: int = 3):
+    logger.info(f"Starting to asynchronously write, concurrency = {concurrency}")
+
+    stop_event = asyncio.Event()
+
+    stmt = cql.prepare(f"INSERT INTO {keyspace}.{table} (pk, c) VALUES (?, ?)")
+    stmt.consistency_level = ConsistencyLevel.QUORUM
+    rd_stmt = cql.prepare(f"SELECT * FROM {keyspace}.{table} WHERE pk = ?")
+    rd_stmt.consistency_level = ConsistencyLevel.QUORUM
+
+    key_gen = KeyGenerator()
+
+    async def do_writes(worker_id: int):
+        write_count = 0
+        while not stop_event.is_set():
+            pk = key_gen.next_pk()
+            await cql.run_async(stmt, [pk, pk])
+            # Check read-your-writes
+            rows = await cql.run_async(rd_stmt, [pk])
+            assert(len(rows) == 1)
+            assert(rows[0].c == pk)
+            write_count += 1
+        logger.info(f"Worker #{worker_id} did {write_count} successful writes")
+
+    tasks = [asyncio.create_task(do_writes(worker_id)) for worker_id in range(concurrency)]
+
+    async def finish():
+        logger.info("Stopping workers")
+        stop_event.set()
+        await asyncio.gather(*tasks)
+
+        last = key_gen.last_pk()
+        if last is not None:
+            return last + 1
+        return 0
+
+    return finish
+
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_intranode_migration(manager: ManagerClient):
+    logger.info("Bootstrapping cluster")
+    cmdline = [
+        '--logger-log-level', 'storage_service=trace',
+        '--logger-log-level', 'stream_session=trace',
+        '--logger-log-level', 'tablets=trace',
+        '--logger-log-level', 'database=trace',
+    ]
+    servers = [await manager.server_add(cmdline=cmdline)]
+
+    await manager.api.disable_tablet_balancing(servers[0].ip_addr)
+
+    cql = manager.get_cql()
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} AND tablets = {'initial': 1};")
+    await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int);")
+
+    finish_writes = await start_writes(cql, "test", "test")
+
+    tablet_token = 0 # Doesn't matter since there is one tablet
+    replica = await get_tablet_replica(manager, servers[0], 'test', 'test', tablet_token)
+
+    s0_host_id = await manager.get_host_id(servers[0].server_id)
+    src_shard = replica[1]
+    dst_shard = src_shard ^ 1
+
+    await manager.api.move_tablet(servers[0].ip_addr, "test", "test", replica[0], src_shard, replica[0], dst_shard, tablet_token)
+
+    key_count = await finish_writes()
+
+    rows = await cql.run_async("SELECT * FROM test.test;")
+    assert len(rows) == key_count
+    for r in rows:
+        assert r.c == r.pk

--- a/test/topology_experimental_raft/test_tablets_intranode.py
+++ b/test/topology_experimental_raft/test_tablets_intranode.py
@@ -46,10 +46,13 @@ class KeyGenerator:
         with self.pk_lock:
             return self.pk
 
-async def start_writes(cql: Session, keyspace: str, table: str, concurrency: int = 3):
+async def start_writes(cql: Session, keyspace: str, table: str, concurrency: int = 3, ignore_errors=False):
     logger.info(f"Starting to asynchronously write, concurrency = {concurrency}")
 
     stop_event = asyncio.Event()
+
+    warmup_writes = 128 // concurrency
+    warmup_event = asyncio.Event()
 
     stmt = cql.prepare(f"INSERT INTO {keyspace}.{table} (pk, c) VALUES (?, ?)")
     stmt.consistency_level = ConsistencyLevel.QUORUM
@@ -62,15 +65,32 @@ async def start_writes(cql: Session, keyspace: str, table: str, concurrency: int
         write_count = 0
         while not stop_event.is_set():
             pk = key_gen.next_pk()
-            await cql.run_async(stmt, [pk, pk])
-            # Check read-your-writes
-            rows = await cql.run_async(rd_stmt, [pk])
-            assert(len(rows) == 1)
-            assert(rows[0].c == pk)
-            write_count += 1
+
+            # Once next_pk() is produced, key_gen.last_key() is assumed to be in the database
+            # hence we can't give up on it.
+            while True:
+                try:
+                    await cql.run_async(stmt, [pk, pk])
+                    # Check read-your-writes
+                    rows = await cql.run_async(rd_stmt, [pk])
+                    assert(len(rows) == 1)
+                    assert(rows[0].c == pk)
+                    write_count += 1
+                    break
+                except Exception as e:
+                    if ignore_errors:
+                        pass # Expected when node is brought down temporarily
+                    else:
+                        raise e
+
+            if pk == warmup_writes:
+                warmup_event.set()
+
         logger.info(f"Worker #{worker_id} did {write_count} successful writes")
 
     tasks = [asyncio.create_task(do_writes(worker_id)) for worker_id in range(concurrency)]
+
+    await asyncio.wait_for(warmup_event.wait(), timeout=60)
 
     async def finish():
         logger.info("Stopping workers")
@@ -113,6 +133,57 @@ async def test_intranode_migration(manager: ManagerClient):
     dst_shard = src_shard ^ 1
 
     await manager.api.move_tablet(servers[0].ip_addr, "test", "test", replica[0], src_shard, replica[0], dst_shard, tablet_token)
+
+    key_count = await finish_writes()
+
+    rows = await cql.run_async("SELECT * FROM test.test;")
+    assert len(rows) == key_count
+    for r in rows:
+        assert r.c == r.pk
+
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_crash_during_intranode_migration(manager: ManagerClient):
+    cmdline = [
+        '--logger-log-level', 'tablets=trace',
+        '--logger-log-level', 'database=trace',
+        '--commitlog-sync', 'batch', # So that ACKed writes are not lost on crash
+    ]
+    servers = [await manager.server_add(cmdline=cmdline)]
+
+    await manager.api.disable_tablet_balancing(servers[0].ip_addr)
+
+    cql = manager.get_cql()
+
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}"
+                        " AND tablets = {'initial': 4};")
+    await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int);")
+
+    finish_writes = await start_writes(cql, "test", "test", ignore_errors=True)
+
+    tablet_token = 0 # Choose one tablet, any of them
+    replica = await get_tablet_replica(manager, servers[0], 'test', 'test', tablet_token)
+
+    src_shard = replica[1]
+    dst_shard = src_shard ^ 1
+
+    await manager.api.enable_injection(servers[0].ip_addr, 'crash-in-tablet-write-both-read-new', one_shot=True)
+
+    migration_task = asyncio.create_task(manager.api.move_tablet(servers[0].ip_addr, "test", "test",
+                                                replica[0], src_shard, replica[0], dst_shard, tablet_token))
+
+    s0_logs = await manager.server_open_log(servers[0].server_id)
+    await s0_logs.wait_for('crash-in-tablet-write-both-read-new hit')
+    await manager.rolling_restart(servers)
+
+    # Wait for the tablet migration to finish
+    await manager.api.quiesce_topology(servers[0].ip_addr)
+
+    try:
+        await migration_task
+    except:
+        pass
 
     key_count = await finish_writes()
 

--- a/test/topology_experimental_raft/test_tablets_intranode.py
+++ b/test/topology_experimental_raft/test_tablets_intranode.py
@@ -191,3 +191,70 @@ async def test_crash_during_intranode_migration(manager: ManagerClient):
     assert len(rows) == key_count
     for r in rows:
         assert r.c == r.pk
+
+
+@pytest.mark.asyncio
+@skip_mode('release', 'error injections are not supported in release mode')
+async def test_cross_shard_migration(manager: ManagerClient):
+    """
+    Test scenario where writes are concurrently made with migration, where
+    some of them are coordinated by the owning host and some by the non-owning host.
+
+    This reproduces the following problem with sharder logic:
+      1) node A: tablet is in stage write_both_read_new (replicas: B:1 -> A:1)
+      2) node B: tablet is in stage write_both_read_new
+      3) node A: tablet is in stage use_new
+      4) node B: coordinate write to node A (since stage is still "write both" here)
+      5) node A: receive write request, sharder thinks no shard owns the tablet, fails the write
+
+    In this scenario, sharder on node A should still return shard 1.
+    """
+
+    logger.info("Bootstrapping cluster")
+    cmdline = [
+        '--logger-log-level', 'storage_service=trace',
+        '--logger-log-level', 'tablets=trace',
+        '--logger-log-level', 'database=trace',
+    ]
+
+    servers = await manager.servers_add(2, cmdline=cmdline)
+
+    await manager.api.disable_tablet_balancing(servers[0].ip_addr)
+
+    cql = manager.get_cql()
+    await cql.run_async("CREATE KEYSPACE test WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1}"
+                        " AND tablets = {'initial': 2};")
+    await cql.run_async("CREATE TABLE test.test (pk int PRIMARY KEY, c int);")
+
+    finish_writes = await start_writes(cql, "test", "test")
+
+    tablet0_token = -1
+    tablet1_token = 1
+    replica0 = await get_tablet_replica(manager, servers[0], 'test', 'test', tablet0_token)
+    replica1 = await get_tablet_replica(manager, servers[0], 'test', 'test', tablet1_token)
+
+    s0_host_id = await manager.get_host_id(servers[0].server_id)
+    s1_host_id = await manager.get_host_id(servers[1].server_id)
+
+    # Place tablets on non-zero shards so that defaulted shard (0) is never the right shard.
+    # This is to catch the problem when sharder (incorrectly) thinks that tablet does not have
+    # any replica on the current host and assigns shard 0 to it in shard_for_read().
+    await manager.api.move_tablet(servers[0].ip_addr, "test", "test", replica0[0], replica0[1], s0_host_id, 1, tablet0_token)
+    await manager.api.move_tablet(servers[0].ip_addr, "test", "test", replica1[0], replica1[1], s1_host_id, 1, tablet1_token)
+
+    # Put whole token ring into migration so that all requests hit the migration path. Half of them
+    # will be coordinated by the owning host, half will be coordinated by the non-owning host.
+    migration0 = asyncio.create_task(manager.api.move_tablet(servers[0].ip_addr, "test", "test",
+                                                             s0_host_id, 1, s1_host_id, 1, tablet0_token))
+    migration1 = asyncio.create_task(manager.api.move_tablet(servers[0].ip_addr, "test", "test",
+                                                             s1_host_id, 1, s0_host_id, 1, tablet1_token))
+
+    await migration0
+    await migration1
+
+    key_count = await finish_writes()
+
+    rows = await cql.run_async("SELECT * FROM test.test;")
+    assert len(rows) == key_count
+    for r in rows:
+        assert r.c == r.pk


### PR DESCRIPTION
With intra-node migration, all the movement is local, so we can make streaming faster by just cloning the sstable set of leaving replica and loading it into the pending one.

This cloning is underlying storage specific, but s3 doesn't support snapshot() yet (th sstables::storage procedure which clone is built upon). It's only supported by file system, with help of hard links. A new generation is picked for new cloned sstable, and it will live in the same directory as the original.

A challenge I bumped into was to understand why table refused to load the sstable at pending replica, as it considered them foreign. Later I realized that sharder (for reads) at this point of migration will point only to leaving replica. It didn't fail with mutation based streaming, because the sstable writer considers the shard that the sstable was written into as its owner, regardless of what sharder says. That was fixed by mimicking this behavior during loading at pending.

test:
./test.py --mode=dev intranode --repeat=100 passes.

